### PR TITLE
Add archive worktree button and CI checks GitHub links

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -206,7 +206,13 @@ export function Sidebar() {
                           })
                         }
                         onRename={(newName) => renameWs(ws.id, newName)}
-                        onArchive={() => archiveWs(ws.id)}
+                        onArchive={async () => {
+                          try {
+                            await archiveWs(ws.id);
+                          } catch (e) {
+                            setRepoError(`Failed to archive "${ws.name}": ${String(e)}`);
+                          }
+                        }}
                       />
                     ))}
                   </>

--- a/src/components/sidebar/ChecksPanel.tsx
+++ b/src/components/sidebar/ChecksPanel.tsx
@@ -30,12 +30,6 @@ function CheckRow({ check }: { check: PrCheck }) {
       ? "var(--error)"
       : "var(--text-muted)";
 
-  const conclusionColor = isSuccess
-    ? "var(--success)"
-    : isFailure
-      ? "var(--error)"
-      : "var(--text-muted)";
-
   const content = (
     <>
       <span
@@ -53,7 +47,7 @@ function CheckRow({ check }: { check: PrCheck }) {
       )}
       <span
         className="ml-auto flex-shrink-0"
-        style={{ color: conclusionColor }}
+        style={{ color: dotColor }}
       >
         {check.conclusion?.toLowerCase() ?? "pending"}
       </span>

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -77,6 +77,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       });
     } catch (e) {
       set({ error: String(e) });
+      throw e;
     }
   },
 


### PR DESCRIPTION
Add archive button to active worktrees for quick archiving. Make CI checks clickable to view GitHub details. Add PR number link to GitHub in checks panel header.

- Archive button visible on hover next to link button in workspace items
- CI checks now link to their GitHub Actions details when available
- External link icons indicate clickable elements