### PR TITLE
Add .context directory auto-creation for inter-agent collaboration

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -57,6 +57,11 @@ pub fn create_workspace(
         request.base_branch.as_deref(),
     )?;
 
+    // Create .context directory for inter-agent collaboration
+    let context_dir = worktree_path.join(".context");
+    let _ = std::fs::create_dir_all(&context_dir);
+    let _ = std::fs::write(context_dir.join(".gitignore"), "*\n!.gitignore\n");
+
     // Apply sparse checkout if needed
     if let Some(ref dirs) = request.sparse_dirs {
         if !dirs.is_empty() {
@@ -415,6 +420,11 @@ pub fn restore_workspace(
             ws.worktree_path.display()
         )));
     }
+
+    // Ensure .context directory exists for inter-agent collaboration
+    let context_dir = ws.worktree_path.join(".context");
+    let _ = std::fs::create_dir_all(&context_dir);
+    let _ = std::fs::write(context_dir.join(".gitignore"), "*\n!.gitignore\n");
 
     // Update status
     ws.status = WorkspaceStatus::Active;


### PR DESCRIPTION
## Summary
- Auto-creates a `.context/` directory with a `.gitignore` (`*` + `!.gitignore`) inside each workspace worktree on creation and on restore from archive
- Enables inter-agent file collaboration within workspaces while keeping `.context/` contents out of git

## Test plan
- [x] `cargo build` passes
- [x] `npm run test` passes (1673 tests)
- [ ] Create a new workspace and verify `.context/` directory exists with `.gitignore` inside
- [ ] Archive and restore a workspace and verify `.context/` directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)