### PR TITLE
Add PR review comment sync from GitHub

### DIFF
--- a/src-tauri/src/commands/pr.rs
+++ b/src-tauri/src/commands/pr.rs
@@ -1,5 +1,5 @@
 use crate::error::AppError;
-use crate::models::pr::{CreatePrRequest, MergeResult, PrCheck, PrInfo};
+use crate::models::pr::{CreatePrRequest, MergeResult, PrCheck, PrComment, PrInfo, PrReview};
 use crate::services::gh as gh_svc;
 use crate::state::AppState;
 use tauri::{Emitter, State};
@@ -190,4 +190,44 @@ pub fn merge_pr(
     let _ = app.emit(&format!("pr-merged:{}", ws_id), &result);
 
     Ok(result)
+}
+
+#[tauri::command]
+pub fn get_pr_reviews(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<Vec<PrReview>, AppError> {
+    let ws_id: Uuid = workspace_id
+        .parse()
+        .map_err(|_| AppError::WorkspaceNotFound(Uuid::nil()))?;
+
+    let worktree_path = {
+        let workspaces = state.workspaces.lock().unwrap();
+        let ws = workspaces
+            .get(&ws_id)
+            .ok_or(AppError::WorkspaceNotFound(ws_id))?;
+        ws.worktree_path.clone()
+    };
+
+    gh_svc::get_pr_reviews(&worktree_path)
+}
+
+#[tauri::command]
+pub fn get_pr_review_comments(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<Vec<PrComment>, AppError> {
+    let ws_id: Uuid = workspace_id
+        .parse()
+        .map_err(|_| AppError::WorkspaceNotFound(Uuid::nil()))?;
+
+    let worktree_path = {
+        let workspaces = state.workspaces.lock().unwrap();
+        let ws = workspaces
+            .get(&ws_id)
+            .ok_or(AppError::WorkspaceNotFound(ws_id))?;
+        ws.worktree_path.clone()
+    };
+
+    gh_svc::get_pr_review_comments(&worktree_path)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,8 @@ pub fn run() {
             commands::pr::push_changes,
             commands::pr::fix_failing_checks,
             commands::pr::merge_pr,
+            commands::pr::get_pr_reviews,
+            commands::pr::get_pr_review_comments,
             // Todo commands
             commands::todo::add_todo,
             commands::todo::update_todo,

--- a/src-tauri/src/models/pr.rs
+++ b/src-tauri/src/models/pr.rs
@@ -53,3 +53,24 @@ pub struct MergeResult {
     pub message: String,
     pub merge_method: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrComment {
+    pub id: u64,
+    pub author: String,
+    pub body: String,
+    pub created_at: String,
+    pub path: Option<String>,
+    pub line: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrReview {
+    pub id: u64,
+    pub author: String,
+    pub state: String,
+    pub body: String,
+    pub submitted_at: String,
+}

--- a/src-tauri/src/services/gh.rs
+++ b/src-tauri/src/services/gh.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::error::AppError;
-use crate::models::pr::{MergeResult, PrCheck, PrInfo};
+use crate::models::pr::{MergeResult, PrCheck, PrComment, PrInfo, PrReview};
 
 pub fn find_gh_binary() -> Result<std::path::PathBuf, AppError> {
     which::which("gh").map_err(|_| {
@@ -198,4 +198,138 @@ pub fn merge_pr(worktree_path: &Path, method: &str) -> Result<MergeResult, AppEr
         message,
         merge_method: method.to_string(),
     })
+}
+
+pub fn get_pr_reviews(worktree_path: &Path) -> Result<Vec<PrReview>, AppError> {
+    let gh = find_gh_binary()?;
+    let output = Command::new(&gh)
+        .args(["pr", "view", "--json", "latestReviews"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::PrError(format!("Failed to run gh pr view: {}", e)))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let raw: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::PrError(format!("Failed to parse reviews output: {}", e)))?;
+
+    let reviews = raw
+        .get("latestReviews")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(reviews
+        .iter()
+        .map(|r| PrReview {
+            id: r.get("id").and_then(|v| v.as_u64()).unwrap_or(0),
+            author: r
+                .get("author")
+                .and_then(|v| v.get("login"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            state: r
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            body: r
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            submitted_at: r
+                .get("submittedAt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        })
+        .collect())
+}
+
+pub fn get_pr_review_comments(worktree_path: &Path) -> Result<Vec<PrComment>, AppError> {
+    let gh = find_gh_binary()?;
+
+    // First get PR number and URL to extract owner/repo
+    let pr_output = Command::new(&gh)
+        .args(["pr", "view", "--json", "number,url"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::PrError(format!("Failed to run gh pr view: {}", e)))?;
+
+    if !pr_output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let pr_raw: serde_json::Value = serde_json::from_slice(&pr_output.stdout)
+        .map_err(|e| AppError::PrError(format!("Failed to parse PR output: {}", e)))?;
+
+    let pr_number = pr_raw
+        .get("number")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| AppError::PrError("No PR number found".to_string()))?;
+
+    let pr_url = pr_raw
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::PrError("No PR URL found".to_string()))?;
+
+    // Extract owner/repo from URL like https://github.com/owner/repo/pull/123
+    let parts: Vec<&str> = pr_url.split('/').collect();
+    if parts.len() < 5 {
+        return Err(AppError::PrError(format!(
+            "Could not parse owner/repo from URL: {}",
+            pr_url
+        )));
+    }
+    let owner = parts[parts.len() - 4];
+    let repo = parts[parts.len() - 3];
+
+    // Fetch inline review comments via API
+    let api_path = format!("repos/{}/{}/pulls/{}/comments", owner, repo, pr_number);
+    let api_output = Command::new(&gh)
+        .args(["api", &api_path, "--paginate"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::PrError(format!("Failed to run gh api: {}", e)))?;
+
+    if !api_output.status.success() {
+        let stderr = String::from_utf8_lossy(&api_output.stderr);
+        return Err(AppError::PrError(format!("gh api failed: {}", stderr)));
+    }
+
+    let raw: Vec<serde_json::Value> = serde_json::from_slice(&api_output.stdout)
+        .map_err(|e| AppError::PrError(format!("Failed to parse review comments: {}", e)))?;
+
+    Ok(raw
+        .iter()
+        .map(|c| PrComment {
+            id: c.get("id").and_then(|v| v.as_u64()).unwrap_or(0),
+            author: c
+                .get("user")
+                .and_then(|v| v.get("login"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            body: c
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            created_at: c
+                .get("created_at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            path: c.get("path").and_then(|v| v.as_str()).map(String::from),
+            line: c
+                .get("line")
+                .and_then(|v| v.as_u64())
+                .or_else(|| c.get("original_line").and_then(|v| v.as_u64()))
+                .map(|v| v as u32),
+        })
+        .collect())
 }

--- a/src/components/sidebar/ChecksPanel.test.tsx
+++ b/src/components/sidebar/ChecksPanel.test.tsx
@@ -36,6 +36,8 @@ const mockFixFailingChecks = vi.fn().mockResolvedValue("Fix CI errors");
 const mockMergePr = vi.fn().mockResolvedValue({ success: true, message: "Merged", mergeMethod: "squash" });
 const mockListTodos = vi.fn().mockResolvedValue([]);
 const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+const mockGetPrReviews = vi.fn().mockResolvedValue([]);
+const mockGetPrReviewComments = vi.fn().mockResolvedValue([]);
 
 vi.mock("../../lib/tauri", () => ({
   getPrInfo: (...args: unknown[]) => mockGetPrInfo(...args),
@@ -45,6 +47,8 @@ vi.mock("../../lib/tauri", () => ({
   fixFailingChecks: (...args: unknown[]) => mockFixFailingChecks(...args),
   mergePr: (...args: unknown[]) => mockMergePr(...args),
   listTodos: (...args: unknown[]) => mockListTodos(...args),
+  getPrReviews: (...args: unknown[]) => mockGetPrReviews(...args),
+  getPrReviewComments: (...args: unknown[]) => mockGetPrReviewComments(...args),
   listen: vi.fn().mockResolvedValue(() => {}),
   listChatMessages: vi.fn().mockResolvedValue([]),
   saveChatMessage: vi.fn().mockResolvedValue(undefined),
@@ -76,6 +80,8 @@ function setupOpenPr(overrides: Partial<PrInfo> = {}) {
 beforeEach(() => {
   usePrStore.setState({
     prInfo: {},
+    reviews: {},
+    reviewComments: {},
     loading: {},
     error: {},
     subscriptions: {},
@@ -902,5 +908,168 @@ describe("ChecksPanel", () => {
       expect(screen.getByText("Build")).toBeInTheDocument();
     });
     expect(startPollingSpy).not.toHaveBeenCalled();
+  });
+
+  // === Reviews ===
+
+  it("shows Reviews section when reviews exist", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 1, author: "alice", state: "APPROVED", body: "LGTM", submittedAt: "" },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("@alice")).toBeInTheDocument();
+      expect(screen.getByText("approved")).toBeInTheDocument();
+    });
+  });
+
+  it("shows CHANGES_REQUESTED review", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 2, author: "bob", state: "CHANGES_REQUESTED", body: "Needs work", submittedAt: "" },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("@bob")).toBeInTheDocument();
+      expect(screen.getByText("changes requested")).toBeInTheDocument();
+      expect(screen.getByText("Needs work")).toBeInTheDocument();
+    });
+  });
+
+  it("shows COMMENTED review", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 3, author: "carol", state: "COMMENTED", body: "", submittedAt: "" },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("@carol")).toBeInTheDocument();
+      expect(screen.getByText("commented")).toBeInTheDocument();
+    });
+  });
+
+  it("shows inline review comments with file path and line", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviewComments: {
+        "ws-1": [
+          { id: 10, author: "dave", body: "Fix this variable", createdAt: "", path: "src/foo.ts", line: 42 },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("@dave")).toBeInTheDocument();
+      expect(screen.getByText("src/foo.ts:42")).toBeInTheDocument();
+      expect(screen.getByText("Fix this variable")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Reviews count header", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 1, author: "alice", state: "APPROVED", body: "", submittedAt: "" },
+        ],
+      },
+      reviewComments: {
+        "ws-1": [
+          { id: 10, author: "bob", body: "Fix", createdAt: "", path: "src/a.ts", line: 1 },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Reviews (2)")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show Reviews section when no reviews", async () => {
+    setupOpenPr();
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("#42")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Reviews/)).not.toBeInTheDocument();
+  });
+
+  it("shows Send to agent button when reviews exist", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 1, author: "alice", state: "CHANGES_REQUESTED", body: "Fix types", submittedAt: "" },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Send to agent")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show Send to agent when no reviews", async () => {
+    setupOpenPr();
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("#42")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Send to agent")).not.toBeInTheDocument();
+  });
+
+  it("sends review feedback to agent on Send to agent click", async () => {
+    const reviewData = [
+      { id: 1, author: "alice", state: "CHANGES_REQUESTED", body: "Fix the types", submittedAt: "" },
+    ];
+    mockGetPrReviews.mockResolvedValue(reviewData);
+    mockGetPrReviewComments.mockResolvedValue([]);
+    setupOpenPr();
+    usePrStore.setState({
+      reviews: { "ws-1": reviewData },
+      reviewComments: { "ws-1": [] },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Send to agent")).toBeInTheDocument();
+    });
+    const addUserMsgSpy = vi.spyOn(useChatStore.getState(), "addUserMessage");
+    const sendMsgSpy = vi.spyOn(useAgentStore.getState(), "sendMessage");
+    await act(async () => {
+      fireEvent.click(screen.getByText("Send to agent"));
+    });
+    await waitFor(() => {
+      expect(addUserMsgSpy).toHaveBeenCalledWith("ws-1", expect.stringContaining("@alice"));
+      expect(sendMsgSpy).toHaveBeenCalledWith("ws-1", expect.stringContaining("CHANGES_REQUESTED"), "workspace");
+    });
+  });
+
+  it("shows review comment without line number when line is null", async () => {
+    setupOpenPr();
+    usePrStore.setState({
+      reviewComments: {
+        "ws-1": [
+          { id: 11, author: "eve", body: "Check this file", createdAt: "", path: "src/bar.ts", line: null },
+        ],
+      },
+    });
+    render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("@eve")).toBeInTheDocument();
+      expect(screen.getByText("src/bar.ts")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/sidebar/ChecksPanel.tsx
+++ b/src/components/sidebar/ChecksPanel.tsx
@@ -5,7 +5,10 @@ import { useTodoStore } from "../../stores/todoStore";
 import { useChatStore } from "../../stores/chatStore";
 import { useAgentStore } from "../../stores/agentStore";
 import { ExternalLink } from "lucide-react";
-import type { PrCheck } from "../../lib/tauri";
+import type { PrCheck, PrReview, PrComment } from "../../lib/tauri";
+
+const EMPTY_REVIEWS: PrReview[] = [];
+const EMPTY_COMMENTS: PrComment[] = [];
 
 interface Props {
   workspaceId: string;
@@ -70,6 +73,92 @@ function CheckRow({ check }: { check: PrCheck }) {
   return (
     <div className="group/check flex items-center gap-2 px-2 py-1 text-xs">
       {content}
+    </div>
+  );
+}
+
+function reviewStateColor(state: string): string {
+  switch (state) {
+    case "APPROVED":
+      return "var(--success)";
+    case "CHANGES_REQUESTED":
+      return "var(--error)";
+    default:
+      return "var(--text-muted)";
+  }
+}
+
+function reviewStateLabel(state: string): string {
+  switch (state) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes requested";
+    default:
+      return "commented";
+  }
+}
+
+function ReviewRow({ review }: { review: PrReview }) {
+  const color = reviewStateColor(review.state);
+
+  return (
+    <div className="flex flex-col gap-0.5 px-2 py-1 text-xs">
+      <div className="flex items-center gap-2">
+        <span
+          className="h-2 w-2 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+        <span className="truncate font-medium" style={{ color: "var(--text-primary)" }}>
+          @{review.author}
+        </span>
+        <span
+          className="ml-auto flex-shrink-0"
+          style={{ color }}
+        >
+          {reviewStateLabel(review.state)}
+        </span>
+      </div>
+      {review.body && (
+        <p
+          className="truncate pl-4 text-[10px]"
+          style={{ color: "var(--text-muted)" }}
+        >
+          {review.body}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ReviewCommentRow({ comment }: { comment: PrComment }) {
+  const location = comment.path
+    ? comment.line
+      ? `${comment.path}:${comment.line}`
+      : comment.path
+    : null;
+
+  return (
+    <div className="flex flex-col gap-0.5 px-2 py-1 text-xs">
+      <div className="flex items-center gap-2">
+        <span className="font-medium" style={{ color: "var(--text-primary)" }}>
+          @{comment.author}
+        </span>
+        {location && (
+          <span
+            className="truncate text-[10px]"
+            style={{ color: "var(--accent)" }}
+          >
+            {location}
+          </span>
+        )}
+      </div>
+      <p
+        className="truncate pl-0 text-[10px]"
+        style={{ color: "var(--text-muted)" }}
+      >
+        {comment.body}
+      </p>
     </div>
   );
 }
@@ -170,6 +259,8 @@ function CreatePRInline({
 
 export function ChecksPanel({ workspaceId }: Props) {
   const prInfo = usePrStore((s) => s.prInfo[workspaceId] ?? null);
+  const reviews = usePrStore((s) => s.reviews[workspaceId] ?? EMPTY_REVIEWS);
+  const reviewComments = usePrStore((s) => s.reviewComments[workspaceId] ?? EMPTY_COMMENTS);
   const loading = usePrStore((s) => s.loading[workspaceId] ?? false);
   const error = usePrStore((s) => s.error[workspaceId] ?? null);
 
@@ -200,6 +291,7 @@ export function ChecksPanel({ workspaceId }: Props) {
   );
   const todosAllCompleted = todoTotal > 0 && todoCompleted === todoTotal;
   const hasPendingTodos = todoTotal > 0 && !todosAllCompleted;
+  const hasReviewFeedback = reviews.length > 0 || reviewComments.length > 0;
 
   useEffect(() => {
     useTodoStore.getState().loadTodos(workspaceId);
@@ -219,6 +311,15 @@ export function ChecksPanel({ workspaceId }: Props) {
     } catch (e) {
       console.error("[ChecksPanel] Failed to generate fix:", e);
     }
+  };
+
+  const handleSendReviews = () => {
+    const message = usePrStore.getState().getReviewFixMessage(workspaceId);
+    if (message === "No review feedback found.") return;
+    useChatStore.getState().addUserMessage(workspaceId, message);
+    useAgentStore
+      .getState()
+      .sendMessage(workspaceId, message, "workspace");
   };
 
   // No PR yet - show creation form
@@ -390,6 +491,30 @@ export function ChecksPanel({ workspaceId }: Props) {
         )}
       </div>
 
+      {/* Reviews */}
+      {hasReviewFeedback && (
+        <div className="px-3 py-1">
+          <div
+            className="mb-1 text-[10px]"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Reviews ({reviews.length + reviewComments.length})
+          </div>
+
+          <div
+            className="space-y-0.5 rounded p-1"
+            style={{ backgroundColor: "var(--bg-primary)" }}
+          >
+            {reviews.map((review) => (
+              <ReviewRow key={review.id} review={review} />
+            ))}
+            {reviewComments.map((comment) => (
+              <ReviewCommentRow key={comment.id} comment={comment} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Actions */}
       <div className="mt-auto flex flex-wrap items-center gap-1.5 px-3 py-2">
         <button
@@ -414,6 +539,19 @@ export function ChecksPanel({ workspaceId }: Props) {
             }}
           >
             Fix with Claude
+          </button>
+        )}
+
+        {hasReviewFeedback && (
+          <button
+            onClick={handleSendReviews}
+            className="rounded px-2 py-0.5 text-[10px]"
+            style={{
+              backgroundColor: "var(--accent)",
+              color: "var(--bg-primary)",
+            }}
+          >
+            Send to agent
           </button>
         )}
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -585,6 +585,35 @@ export async function mergePr(
   return invoke<MergeResult>("merge_pr", { workspaceId, mergeMethod });
 }
 
+export interface PrComment {
+  id: number;
+  author: string;
+  body: string;
+  createdAt: string;
+  path: string | null;
+  line: number | null;
+}
+
+export interface PrReview {
+  id: number;
+  author: string;
+  state: string;
+  body: string;
+  submittedAt: string;
+}
+
+export async function getPrReviews(
+  workspaceId: string,
+): Promise<PrReview[]> {
+  return invoke<PrReview[]>("get_pr_reviews", { workspaceId });
+}
+
+export async function getPrReviewComments(
+  workspaceId: string,
+): Promise<PrComment[]> {
+  return invoke<PrComment[]>("get_pr_review_comments", { workspaceId });
+}
+
 // Todo types
 export interface TodoItem {
   id: string;

--- a/src/stores/prStore.test.ts
+++ b/src/stores/prStore.test.ts
@@ -11,6 +11,8 @@ vi.mock("../lib/tauri", () => ({
   pushChanges: vi.fn(),
   fixFailingChecks: vi.fn(),
   mergePr: vi.fn(),
+  getPrReviews: vi.fn(),
+  getPrReviewComments: vi.fn(),
 }));
 
 import { usePrStore } from "./prStore";
@@ -22,6 +24,8 @@ import {
   pushChanges,
   fixFailingChecks,
   mergePr,
+  getPrReviews,
+  getPrReviewComments,
 } from "../lib/tauri";
 
 const makePrInfo = (overrides: Record<string, unknown> = {}) => ({
@@ -40,6 +44,8 @@ beforeEach(() => {
   usePrStore.setState(
     {
       prInfo: {},
+      reviews: {},
+      reviewComments: {},
       loading: {},
       error: {},
       subscriptions: {},
@@ -414,5 +420,107 @@ describe("prStore - getters", () => {
     expect(usePrStore.getState().getError("ws-1")).toBeNull();
     usePrStore.setState({ error: { "ws-1": "some error" } });
     expect(usePrStore.getState().getError("ws-1")).toBe("some error");
+  });
+
+  it("getReviews returns reviews for known workspace", () => {
+    const reviews = [{ id: 1, author: "alice", state: "APPROVED", body: "", submittedAt: "" }];
+    usePrStore.setState({ reviews: { "ws-1": reviews as any } });
+    expect(usePrStore.getState().getReviews("ws-1")).toEqual(reviews);
+  });
+
+  it("getReviews returns empty array for unknown workspace", () => {
+    expect(usePrStore.getState().getReviews("unknown")).toEqual([]);
+  });
+
+  it("getReviewComments returns comments for known workspace", () => {
+    const comments = [{ id: 1, author: "bob", body: "fix this", createdAt: "", path: "src/foo.ts", line: 42 }];
+    usePrStore.setState({ reviewComments: { "ws-1": comments as any } });
+    expect(usePrStore.getState().getReviewComments("ws-1")).toEqual(comments);
+  });
+
+  it("getReviewComments returns empty array for unknown workspace", () => {
+    expect(usePrStore.getState().getReviewComments("unknown")).toEqual([]);
+  });
+});
+
+describe("prStore - loadReviews", () => {
+  it("fetches and stores reviews and comments", async () => {
+    const reviews = [{ id: 1, author: "alice", state: "CHANGES_REQUESTED", body: "Please fix", submittedAt: "" }];
+    const comments = [{ id: 10, author: "alice", body: "This is wrong", createdAt: "", path: "src/foo.ts", line: 5 }];
+    vi.mocked(getPrReviews).mockResolvedValue(reviews as any);
+    vi.mocked(getPrReviewComments).mockResolvedValue(comments as any);
+
+    await usePrStore.getState().loadReviews("ws-1");
+
+    expect(usePrStore.getState().reviews["ws-1"]).toEqual(reviews);
+    expect(usePrStore.getState().reviewComments["ws-1"]).toEqual(comments);
+  });
+
+  it("handles errors gracefully", async () => {
+    vi.mocked(getPrReviews).mockRejectedValue(new Error("network error"));
+    vi.mocked(getPrReviewComments).mockRejectedValue(new Error("network error"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await usePrStore.getState().loadReviews("ws-1");
+
+    // Should not throw and state should remain empty
+    expect(usePrStore.getState().reviews["ws-1"]).toBeUndefined();
+  });
+});
+
+describe("prStore - getReviewFixMessage", () => {
+  it("returns no feedback message when empty", () => {
+    const msg = usePrStore.getState().getReviewFixMessage("ws-1");
+    expect(msg).toBe("No review feedback found.");
+  });
+
+  it("formats reviews into a message", () => {
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 1, author: "alice", state: "CHANGES_REQUESTED", body: "Please fix the types", submittedAt: "" },
+        ] as any,
+      },
+      reviewComments: { "ws-1": [] },
+    });
+
+    const msg = usePrStore.getState().getReviewFixMessage("ws-1");
+
+    expect(msg).toContain("@alice");
+    expect(msg).toContain("CHANGES_REQUESTED");
+    expect(msg).toContain("Please fix the types");
+  });
+
+  it("formats inline comments with file paths", () => {
+    usePrStore.setState({
+      reviews: { "ws-1": [] },
+      reviewComments: {
+        "ws-1": [
+          { id: 10, author: "bob", body: "This should be a const", createdAt: "", path: "src/foo.ts", line: 42 },
+        ] as any,
+      },
+    });
+
+    const msg = usePrStore.getState().getReviewFixMessage("ws-1");
+
+    expect(msg).toContain("@bob");
+    expect(msg).toContain("`src/foo.ts:42`");
+    expect(msg).toContain("This should be a const");
+  });
+
+  it("formats review with no body", () => {
+    usePrStore.setState({
+      reviews: {
+        "ws-1": [
+          { id: 1, author: "alice", state: "APPROVED", body: "", submittedAt: "" },
+        ] as any,
+      },
+      reviewComments: { "ws-1": [] },
+    });
+
+    const msg = usePrStore.getState().getReviewFixMessage("ws-1");
+
+    expect(msg).toContain("@alice");
+    expect(msg).toContain("APPROVED");
   });
 });

--- a/src/stores/prStore.ts
+++ b/src/stores/prStore.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   type PrInfo,
+  type PrReview,
+  type PrComment,
   type CreatePrRequest,
   type MergeResult,
   createPr as createPrCmd,
@@ -10,10 +12,14 @@ import {
   pushChanges as pushChangesCmd,
   fixFailingChecks as fixFailingChecksCmd,
   mergePr as mergePrCmd,
+  getPrReviews as getPrReviewsCmd,
+  getPrReviewComments as getPrReviewCommentsCmd,
 } from "../lib/tauri";
 
 interface PrStore {
   prInfo: Record<string, PrInfo | null>;
+  reviews: Record<string, PrReview[]>;
+  reviewComments: Record<string, PrComment[]>;
   loading: Record<string, boolean>;
   error: Record<string, string | null>;
   subscriptions: Record<string, UnlistenFn[]>;
@@ -22,20 +28,26 @@ interface PrStore {
   subscribe: (workspaceId: string) => Promise<void>;
   unsubscribe: (workspaceId: string) => void;
   loadPrInfo: (workspaceId: string) => Promise<void>;
+  loadReviews: (workspaceId: string) => Promise<void>;
   refreshChecks: (workspaceId: string) => Promise<void>;
   createPr: (request: CreatePrRequest) => Promise<PrInfo>;
   pushChanges: (workspaceId: string) => Promise<void>;
   getFixMessage: (workspaceId: string) => Promise<string>;
+  getReviewFixMessage: (workspaceId: string) => string;
   mergePr: (workspaceId: string, method?: string) => Promise<MergeResult>;
   startPolling: (workspaceId: string) => void;
   stopPolling: (workspaceId: string) => void;
   getPrInfo: (workspaceId: string) => PrInfo | null;
+  getReviews: (workspaceId: string) => PrReview[];
+  getReviewComments: (workspaceId: string) => PrComment[];
   isLoading: (workspaceId: string) => boolean;
   getError: (workspaceId: string) => string | null;
 }
 
 export const usePrStore = create<PrStore>((set, get) => ({
   prInfo: {},
+  reviews: {},
+  reviewComments: {},
   loading: {},
   error: {},
   subscriptions: {},
@@ -93,11 +105,30 @@ export const usePrStore = create<PrStore>((set, get) => ({
         prInfo: { ...state.prInfo, [workspaceId]: info },
         loading: { ...state.loading, [workspaceId]: false },
       }));
+      // Load reviews in the background if PR exists
+      if (info.prNumber != null) {
+        get().loadReviews(workspaceId);
+      }
     } catch (e) {
       set((state) => ({
         error: { ...state.error, [workspaceId]: String(e) },
         loading: { ...state.loading, [workspaceId]: false },
       }));
+    }
+  },
+
+  loadReviews: async (workspaceId: string) => {
+    try {
+      const [reviews, comments] = await Promise.all([
+        getPrReviewsCmd(workspaceId),
+        getPrReviewCommentsCmd(workspaceId),
+      ]);
+      set((state) => ({
+        reviews: { ...state.reviews, [workspaceId]: reviews },
+        reviewComments: { ...state.reviewComments, [workspaceId]: comments },
+      }));
+    } catch (e) {
+      console.error(`[prStore] Failed to load reviews for ${workspaceId}:`, e);
     }
   },
 
@@ -114,6 +145,9 @@ export const usePrStore = create<PrStore>((set, get) => ({
           },
         };
       });
+
+      // Also refresh reviews
+      get().loadReviews(workspaceId);
 
       // Stop polling if all checks are completed
       const allDone = checks.every(
@@ -177,6 +211,46 @@ export const usePrStore = create<PrStore>((set, get) => ({
     return fixFailingChecksCmd(workspaceId);
   },
 
+  getReviewFixMessage: (workspaceId: string) => {
+    const reviews = get().reviews[workspaceId] ?? [];
+    const comments = get().reviewComments[workspaceId] ?? [];
+
+    if (reviews.length === 0 && comments.length === 0) {
+      return "No review feedback found.";
+    }
+
+    let message =
+      "The following PR review feedback has been received. Please address these comments:\n\n";
+
+    if (reviews.length > 0) {
+      message += "## Reviews\n";
+      for (const r of reviews) {
+        if (r.body) {
+          message += `- **@${r.author}** (${r.state}): ${r.body}\n`;
+        } else {
+          message += `- **@${r.author}** (${r.state})\n`;
+        }
+      }
+      message += "\n";
+    }
+
+    if (comments.length > 0) {
+      message += "## Inline Comments\n";
+      for (const c of comments) {
+        const location = c.path
+          ? c.line
+            ? `\`${c.path}:${c.line}\``
+            : `\`${c.path}\``
+          : "general";
+        message += `- **@${c.author}** on ${location}: ${c.body}\n`;
+      }
+      message += "\n";
+    }
+
+    message += "Please review and address each piece of feedback.";
+    return message;
+  },
+
   mergePr: async (workspaceId: string, method?: string) => {
     set((state) => ({
       loading: { ...state.loading, [workspaceId]: true },
@@ -229,6 +303,14 @@ export const usePrStore = create<PrStore>((set, get) => ({
 
   isLoading: (workspaceId: string) => {
     return get().loading[workspaceId] ?? false;
+  },
+
+  getReviews: (workspaceId: string) => {
+    return get().reviews[workspaceId] ?? [];
+  },
+
+  getReviewComments: (workspaceId: string) => {
+    return get().reviewComments[workspaceId] ?? [];
   },
 
   getError: (workspaceId: string) => {


### PR DESCRIPTION
## Summary
Fetch PR review comments and threads from GitHub and display them in the sidebar ChecksPanel. Users can now see review feedback without leaving the app and forward comments to Claude via "Send to agent" action.

## Changes
- **Backend**: Added Rust service functions to fetch reviews and inline comments from GitHub via `gh` CLI
- **Store**: Extended prStore with reviews state, loading logic, and message formatting for agent
- **UI**: Added Reviews section to ChecksPanel with colored state badges and "Send to agent" button
- **Tests**: Added comprehensive test coverage for reviews display and agent messaging

Implements full PR review comment sync workflow as specified.