### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fury"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fury"
-version = "1.3.0"
+version = "1.4.0"
 description = "Cross-platform coding agent orchestration"
 authors = ["Tyler Gray"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fury",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.fury.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump version from 1.3.0 to 1.4.0 across `package.json`, `tauri.conf.json`, and `Cargo.toml`

## What's new since v1.3.0
- **Git Sync Button** — Sync workspace branch with one click (#35)
- Documentation updates (#34)

## After merge
```bash
git tag v1.4.0
git push origin v1.4.0
```
This will trigger the release workflow to build for macOS, Linux, and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)