### PR TITLE
Fix macOS release build OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=4096
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS: --max-old-space-size=4096` to the release workflow's build step
- The build workflow already had this, but the release workflow was missing it
- This caused the v1.4.0 macOS builds to crash with "JavaScript heap out of memory" during Vite bundling

## After merge
Delete the failed v1.4.0 tag, re-tag from main, and push to re-trigger the release:
```bash
git tag -d v1.4.0
git push origin :v1.4.0
git fetch origin main
git tag v1.4.0 origin/main
git push origin v1.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)