### PR TITLE
Fix Windows console window flashing on all process spawns

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::error::AppError;
 use crate::models::diff::{DiffResult, FileDiffContent};
+use crate::platform;
 use crate::services::diff as diff_svc;
 use crate::state::AppState;
 use base64::Engine;
@@ -57,7 +57,7 @@ pub fn get_git_log(
     let count = max_count.unwrap_or(100).to_string();
     let format_arg = "--format=%h\x1f%H\x1f%s\x1f%an\x1f%aI";
 
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["log", &format!("--max-count={}", count), format_arg])
         .current_dir(&worktree_path)
         .output()?;
@@ -175,7 +175,7 @@ pub fn list_repo_directories(
     }
     args.push("HEAD");
 
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(&args)
         .current_dir(&repo_path)
         .output()?;
@@ -215,7 +215,7 @@ pub fn list_workspace_files(
         ws.worktree_path.clone()
     };
 
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["ls-tree", "-r", "--name-only", "HEAD"])
         .current_dir(&worktree_path)
         .output()?;
@@ -253,7 +253,7 @@ pub fn list_repo_files(
         repo.path.clone()
     };
 
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["ls-tree", "-r", "--name-only", "HEAD"])
         .current_dir(&repo_path)
         .output()?;
@@ -436,7 +436,7 @@ fn try_format_file(file_path: &std::path::Path, working_dir: &std::path::Path) -
     };
 
     if let Some((cmd, args)) = formatter {
-        let result = Command::new(&cmd)
+        let result = platform::command(&cmd)
             .args(&args)
             .current_dir(working_dir)
             .output();

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -1,5 +1,6 @@
 use crate::error::AppError;
 use crate::models::repository::Repository;
+use crate::platform;
 use crate::services::worktree;
 use crate::state::AppState;
 use std::fs;
@@ -9,7 +10,7 @@ use uuid::Uuid;
 
 /// Get the current checked-out branch for a repo path.
 fn detect_current_branch(path: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let output = platform::command("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(path)
         .output()
@@ -27,7 +28,7 @@ pub fn add_repository(state: State<'_, AppState>, path: String) -> Result<Reposi
     let path = PathBuf::from(&path);
 
     // Validate it's a git repository
-    let git_check = std::process::Command::new("git")
+    let git_check = platform::command("git")
         .args(["rev-parse", "--git-dir"])
         .current_dir(&path)
         .output()?;
@@ -115,7 +116,7 @@ pub fn list_branches(state: State<'_, AppState>, repo_id: String) -> Result<Vec<
     let repos = state.repositories.lock().unwrap();
     let repo = repos.get(&id).ok_or(AppError::RepoNotFound(id))?;
 
-    let output = std::process::Command::new("git")
+    let output = platform::command("git")
         .args(["branch", "--format=%(refname:short)"])
         .current_dir(&repo.path)
         .output()?;
@@ -177,7 +178,7 @@ pub fn clone_repository(
 ) -> Result<Repository, AppError> {
     let dest = PathBuf::from(&path);
 
-    let output = std::process::Command::new("git")
+    let output = platform::command("git")
         .args(["clone", &url, &path])
         .output()?;
 
@@ -201,7 +202,7 @@ pub fn init_repository(
         fs::create_dir_all(&dest)?;
     }
 
-    let output = std::process::Command::new("git")
+    let output = platform::command("git")
         .args(["init"])
         .current_dir(&dest)
         .output()?;
@@ -215,12 +216,12 @@ pub fn init_repository(
     let readme = dest.join("README.md");
     fs::write(&readme, format!("# {}\n", name))?;
 
-    let _ = std::process::Command::new("git")
+    let _ = platform::command("git")
         .args(["add", "."])
         .current_dir(&dest)
         .output();
 
-    let _ = std::process::Command::new("git")
+    let _ = platform::command("git")
         .args(["commit", "-m", "Initial commit"])
         .current_dir(&dest)
         .output();

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -53,7 +53,7 @@ pub fn create_workspace(
     // so create_worktree can find it via refs/heads/<branch>.
     if request.fetch_remote_branch.unwrap_or(false) {
         let refspec = format!("{}:{}", &request.branch_name, &request.branch_name);
-        let fetch_output = std::process::Command::new("git")
+        let fetch_output = crate::platform::command("git")
             .args(["fetch", "origin", &refspec])
             .current_dir(&repo.path)
             .output()
@@ -256,7 +256,7 @@ pub fn update_sparse_dirs(
 
     // Apply or disable sparse checkout
     if dirs.is_empty() {
-        let _ = std::process::Command::new("git")
+        let _ = crate::platform::command("git")
             .args(["sparse-checkout", "disable"])
             .current_dir(&worktree_path)
             .output();

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -67,8 +68,21 @@ pub fn configure_process_group(cmd: &mut Command) -> &mut Command {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200) // CREATE_NEW_PROCESS_GROUP
+        cmd.creation_flags(0x08000200) // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
+}
+
+/// Create a `Command` that hides the console window on Windows.
+/// Use this for all short-lived process spawns (git, formatters, etc.)
+/// to prevent terminal windows from flashing on screen.
+pub fn command(program: impl AsRef<OsStr>) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    cmd
 }
 
 pub fn app_data_dir() -> PathBuf {

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -2,8 +2,10 @@ pub const DEFAULT_SHELL: &str = "powershell.exe";
 pub const SHELL_EXEC_FLAG: &str = "-Command";
 
 pub fn kill_process_group(pid: u32) -> Result<(), std::io::Error> {
+    use std::os::windows::process::CommandExt;
     std::process::Command::new("taskkill")
         .args(["/T", "/F", "/PID", &pid.to_string()])
+        .creation_flags(0x08000000) // CREATE_NO_WINDOW
         .output()?;
     Ok(())
 }

--- a/src-tauri/src/services/branch.rs
+++ b/src-tauri/src/services/branch.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
-use std::process::Command;
 
 use crate::error::AppError;
 use crate::models::diff::{DiffResult, FileDiff, FileDiffContent, FileStatus};
 use crate::models::merge::{
     BranchStatus, ConflictContent, ConflictType, ConflictedFile, PullResult,
 };
+use crate::platform;
 use crate::services::diff::detect_language;
 
 /// Get ahead/behind counts for the current branch relative to the default branch.
@@ -15,7 +15,7 @@ pub fn get_branch_status(
     default_branch: &str,
 ) -> Result<BranchStatus, AppError> {
     // Check if upstream exists
-    let has_upstream = Command::new("git")
+    let has_upstream = platform::command("git")
         .args(["rev-parse", "--verify", &format!("origin/{}", branch)])
         .current_dir(worktree_path)
         .output()
@@ -24,7 +24,7 @@ pub fn get_branch_status(
 
     // Get ahead/behind relative to default branch
     let upstream_ref = format!("origin/{}", default_branch);
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args([
             "rev-list",
             "--left-right",
@@ -61,7 +61,7 @@ pub fn get_branch_status(
 
 /// Fetch from origin.
 pub fn fetch_upstream(worktree_path: &Path) -> Result<(), AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["fetch", "origin"])
         .current_dir(worktree_path)
         .output()?;
@@ -78,7 +78,7 @@ pub fn fetch_upstream(worktree_path: &Path) -> Result<(), AppError> {
 
 /// Pull from upstream with rebase.
 pub fn pull_rebase(worktree_path: &Path, default_branch: &str) -> Result<PullResult, AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["pull", "--rebase", "origin", default_branch])
         .current_dir(worktree_path)
         .output()?;
@@ -102,7 +102,7 @@ pub fn pull_rebase(worktree_path: &Path, default_branch: &str) -> Result<PullRes
 
 /// Pull from upstream with merge.
 pub fn pull_merge(worktree_path: &Path, default_branch: &str) -> Result<PullResult, AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["pull", "origin", default_branch])
         .current_dir(worktree_path)
         .output()?;
@@ -126,7 +126,7 @@ pub fn pull_merge(worktree_path: &Path, default_branch: &str) -> Result<PullResu
 
 /// Get list of files with unmerged entries (conflict markers).
 fn get_unmerged_files(worktree_path: &Path) -> Vec<String> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["diff", "--name-only", "--diff-filter=U"])
         .current_dir(worktree_path)
         .output();
@@ -143,7 +143,7 @@ fn get_unmerged_files(worktree_path: &Path) -> Vec<String> {
 
 /// Get list of conflicted files with their conflict types.
 pub fn get_conflicted_files(worktree_path: &Path) -> Result<Vec<ConflictedFile>, AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["status", "--porcelain=v2"])
         .current_dir(worktree_path)
         .output()?;
@@ -217,7 +217,7 @@ pub fn get_conflict_content(
 /// Get file content at a specific merge stage (1=base, 2=ours, 3=theirs).
 fn git_show_stage(worktree_path: &Path, stage: u8, file_path: &str) -> String {
     let ref_spec = format!(":{}:{}", stage, file_path);
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["show", &ref_spec])
         .current_dir(worktree_path)
         .output();
@@ -236,7 +236,7 @@ pub fn resolve_conflict(
 ) -> Result<(), AppError> {
     match strategy {
         "ours" => {
-            let output = Command::new("git")
+            let output = platform::command("git")
                 .args(["checkout", "--ours", file_path])
                 .current_dir(worktree_path)
                 .output()?;
@@ -247,7 +247,7 @@ pub fn resolve_conflict(
             }
         }
         "theirs" => {
-            let output = Command::new("git")
+            let output = platform::command("git")
                 .args(["checkout", "--theirs", file_path])
                 .current_dir(worktree_path)
                 .output()?;
@@ -262,7 +262,7 @@ pub fn resolve_conflict(
     }
 
     // Stage the resolved file
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["add", file_path])
         .current_dir(worktree_path)
         .output()?;
@@ -279,14 +279,14 @@ pub fn resolve_conflict(
 /// Abort an in-progress merge.
 pub fn abort_merge(worktree_path: &Path) -> Result<(), AppError> {
     // Try merge --abort first, then rebase --abort
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["merge", "--abort"])
         .current_dir(worktree_path)
         .output()?;
 
     if !output.status.success() {
         // May be a rebase instead
-        let rebase_output = Command::new("git")
+        let rebase_output = platform::command("git")
             .args(["rebase", "--abort"])
             .current_dir(worktree_path)
             .output()?;
@@ -304,7 +304,7 @@ pub fn abort_merge(worktree_path: &Path) -> Result<(), AppError> {
 /// Continue merge after all conflicts resolved.
 pub fn continue_merge(worktree_path: &Path) -> Result<(), AppError> {
     // Try rebase --continue first (more common after pull --rebase)
-    let rebase_output = Command::new("git")
+    let rebase_output = platform::command("git")
         .args(["rebase", "--continue"])
         .env("GIT_EDITOR", "true")
         .current_dir(worktree_path)
@@ -315,7 +315,7 @@ pub fn continue_merge(worktree_path: &Path) -> Result<(), AppError> {
     }
 
     // Fall back to committing the merge
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["commit", "--no-edit"])
         .current_dir(worktree_path)
         .output()?;
@@ -339,13 +339,13 @@ pub fn cross_worktree_diff(
     let range = format!("{}...{}", branch_a, branch_b);
 
     // Get file statuses
-    let name_status_output = Command::new("git")
+    let name_status_output = platform::command("git")
         .args(["diff", "--name-status", &range])
         .current_dir(repo_path)
         .output()?;
 
     // Get line counts
-    let numstat_output = Command::new("git")
+    let numstat_output = platform::command("git")
         .args(["diff", "--numstat", &range])
         .current_dir(repo_path)
         .output()?;
@@ -422,7 +422,7 @@ pub fn get_file_at_ref(
 ) -> Result<FileDiffContent, AppError> {
     let original = {
         let ref_spec = format!("{}:{}", branch_a, file_path);
-        let output = Command::new("git")
+        let output = platform::command("git")
             .args(["show", &ref_spec])
             .current_dir(repo_path)
             .output()?;
@@ -435,7 +435,7 @@ pub fn get_file_at_ref(
 
     let modified = {
         let ref_spec = format!("{}:{}", branch_b, file_path);
-        let output = Command::new("git")
+        let output = platform::command("git")
             .args(["show", &ref_spec])
             .current_dir(repo_path)
             .output()?;

--- a/src-tauri/src/services/checkpoint.rs
+++ b/src-tauri/src/services/checkpoint.rs
@@ -1,7 +1,7 @@
 use crate::error::AppError;
 use crate::models::checkpoint::Checkpoint;
+use crate::platform;
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
 use uuid::Uuid;
@@ -34,7 +34,7 @@ pub fn create_checkpoint(
     git_update_ref(worktree_path, &ref_name, &commit_sha)?;
 
     // 5. Unstage everything (leave working directory untouched)
-    let _ = Command::new("git")
+    let _ = platform::command("git")
         .args(["reset", "HEAD"])
         .current_dir(worktree_path)
         .output();
@@ -57,7 +57,7 @@ pub fn create_checkpoint(
 /// Revert the worktree to match a checkpoint's tree state.
 pub fn revert_to_checkpoint(worktree_path: &Path, tree_sha: &str) -> Result<(), AppError> {
     // Replace index and working tree with checkpoint tree
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["read-tree", "--reset", "-u", tree_sha])
         .current_dir(worktree_path)
         .output()?;
@@ -70,7 +70,7 @@ pub fn revert_to_checkpoint(worktree_path: &Path, tree_sha: &str) -> Result<(), 
     }
 
     // Remove files created after the checkpoint
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["clean", "-fd"])
         .current_dir(worktree_path)
         .output()?;
@@ -93,7 +93,7 @@ pub fn delete_checkpoints_after(
 ) -> Result<Vec<String>, AppError> {
     let prefix = format!("refs/fury/checkpoints/{}/", workspace_id);
 
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["for-each-ref", "--format=%(refname)", &prefix])
         .current_dir(worktree_path)
         .output()?;
@@ -119,7 +119,7 @@ pub fn delete_checkpoints_after(
         {
             if let Ok(n) = turn_str.parse::<u32>() {
                 if n > turn_index {
-                    let del_output = Command::new("git")
+                    let del_output = platform::command("git")
                         .args(["update-ref", "-d", ref_name])
                         .current_dir(worktree_path)
                         .output()?;
@@ -139,7 +139,7 @@ pub fn delete_checkpoints_after(
 
 fn git_add_all_with_retry(worktree_path: &Path) -> Result<(), AppError> {
     for attempt in 0..3 {
-        let output = Command::new("git")
+        let output = platform::command("git")
             .args(["add", "--all"])
             .current_dir(worktree_path)
             .output()?;
@@ -163,7 +163,7 @@ fn git_add_all_with_retry(worktree_path: &Path) -> Result<(), AppError> {
 }
 
 fn git_write_tree(worktree_path: &Path) -> Result<String, AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["write-tree"])
         .current_dir(worktree_path)
         .output()?;
@@ -183,7 +183,7 @@ fn git_commit_tree(
     tree_sha: &str,
     message: &str,
 ) -> Result<String, AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["commit-tree", tree_sha, "-m", message])
         .current_dir(worktree_path)
         .output()?;
@@ -199,7 +199,7 @@ fn git_commit_tree(
 }
 
 fn git_update_ref(worktree_path: &Path, ref_name: &str, commit_sha: &str) -> Result<(), AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["update-ref", ref_name, commit_sha])
         .current_dir(worktree_path)
         .output()?;

--- a/src-tauri/src/services/claude_process.rs
+++ b/src-tauri/src/services/claude_process.rs
@@ -225,7 +225,7 @@ pub async fn spawn_and_stream(
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200);
+        cmd.creation_flags(0x08000200); // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
 
     let mut child = cmd.spawn().map_err(|e| {
@@ -345,7 +345,7 @@ pub async fn spawn_persistent(
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200);
+        cmd.creation_flags(0x08000200); // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
 
     let mut child = cmd.spawn().map_err(|e| {

--- a/src-tauri/src/services/codex_process.rs
+++ b/src-tauri/src/services/codex_process.rs
@@ -146,7 +146,7 @@ pub async fn spawn_and_stream(
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200);
+        cmd.creation_flags(0x08000200); // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
 
     let mut child = cmd.spawn().map_err(|e| {

--- a/src-tauri/src/services/copilot_lsp.rs
+++ b/src-tauri/src/services/copilot_lsp.rs
@@ -148,7 +148,7 @@ pub async fn start(root_uri: &str) -> Result<(CopilotLspHandle, Child), AppError
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200);
+        cmd.creation_flags(0x08000200); // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
 
     let mut child = cmd.spawn().map_err(|e| {

--- a/src-tauri/src/services/diff.rs
+++ b/src-tauri/src/services/diff.rs
@@ -1,7 +1,7 @@
 use crate::error::AppError;
 use crate::models::diff::{DiffResult, FileDiff, FileDiffContent, FileStatus};
+use crate::platform;
 use std::path::Path;
-use std::process::Command;
 
 /// Empty tree SHA used as fallback when git merge-base fails.
 const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf899d15363ed7fd1";
@@ -14,19 +14,19 @@ pub fn get_workspace_diff(
     let merge_base = find_merge_base(worktree_path, default_branch);
 
     // Get file statuses (M/A/D/R)
-    let name_status_output = Command::new("git")
+    let name_status_output = platform::command("git")
         .args(["diff", "--name-status", &merge_base])
         .current_dir(worktree_path)
         .output()?;
 
     // Get line counts
-    let numstat_output = Command::new("git")
+    let numstat_output = platform::command("git")
         .args(["diff", "--numstat", &merge_base])
         .current_dir(worktree_path)
         .output()?;
 
     // Get untracked files
-    let untracked_output = Command::new("git")
+    let untracked_output = platform::command("git")
         .args(["ls-files", "--others", "--exclude-standard"])
         .current_dir(worktree_path)
         .output()?;
@@ -129,7 +129,7 @@ pub fn get_file_diff_content(
     let merge_base = find_merge_base(worktree_path, default_branch);
 
     // Get original content at merge base
-    let original_output = Command::new("git")
+    let original_output = platform::command("git")
         .args(["show", &format!("{}:{}", merge_base, file_path)])
         .current_dir(worktree_path)
         .output()?;
@@ -157,7 +157,7 @@ pub fn get_file_diff_content(
 /// Find the merge base between the current HEAD and the default branch.
 /// Falls back to the empty tree SHA if no common ancestor exists.
 fn find_merge_base(worktree_path: &Path, default_branch: &str) -> String {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["merge-base", default_branch, "HEAD"])
         .current_dir(worktree_path)
         .output();

--- a/src-tauri/src/services/gh.rs
+++ b/src-tauri/src/services/gh.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
-use std::process::Command;
 
 use crate::error::AppError;
 use crate::models::pr::{
     IssueDetail, IssueListItem, MergeResult, PrCheck, PrComment, PrDetail, PrInfo, PrListItem,
     PrReview, RunLogsResult, WorkflowJob, WorkflowRun, WorkflowStep,
 };
+use crate::platform;
 
 pub fn find_gh_binary() -> Result<std::path::PathBuf, AppError> {
     which::which("gh").map_err(|_| {
@@ -18,7 +18,7 @@ pub fn find_gh_binary() -> Result<std::path::PathBuf, AppError> {
 
 pub fn check_gh_auth() -> Result<(), AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["auth", "status"])
         .output()
         .map_err(|e| AppError::PrError(format!("Failed to run gh auth status: {}", e)))?;
@@ -32,7 +32,7 @@ pub fn check_gh_auth() -> Result<(), AppError> {
 }
 
 pub fn push_branch(worktree_path: &Path, branch: &str) -> Result<(), AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["push", "-u", "origin", branch])
         .current_dir(worktree_path)
         .output()
@@ -69,7 +69,7 @@ pub fn create_pr(
         args.push("--draft".to_string());
     }
 
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(&args)
         .current_dir(worktree_path)
         .output()
@@ -89,7 +89,7 @@ pub fn create_pr(
 
 pub fn get_pr_info(worktree_path: &Path) -> Result<Option<PrInfo>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["pr", "view", "--json", "number,url,title,state,mergeable"])
         .current_dir(worktree_path)
         .output()
@@ -119,7 +119,7 @@ pub fn get_pr_info(worktree_path: &Path) -> Result<Option<PrInfo>, AppError> {
 
 pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "pr",
             "checks",
@@ -184,7 +184,7 @@ pub fn merge_pr(worktree_path: &Path, method: &str) -> Result<MergeResult, AppEr
         _ => "--merge",
     };
 
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["pr", "merge", merge_flag, "--delete-branch"])
         .current_dir(worktree_path)
         .output()
@@ -205,7 +205,7 @@ pub fn merge_pr(worktree_path: &Path, method: &str) -> Result<MergeResult, AppEr
 
 pub fn get_pr_reviews(worktree_path: &Path) -> Result<Vec<PrReview>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["pr", "view", "--json", "latestReviews"])
         .current_dir(worktree_path)
         .output()
@@ -257,7 +257,7 @@ pub fn get_pr_review_comments(worktree_path: &Path) -> Result<Vec<PrComment>, Ap
     let gh = find_gh_binary()?;
 
     // First get PR number and URL to extract owner/repo
-    let pr_output = Command::new(&gh)
+    let pr_output = platform::command(&gh)
         .args(["pr", "view", "--json", "number,url"])
         .current_dir(worktree_path)
         .output()
@@ -293,7 +293,7 @@ pub fn get_pr_review_comments(worktree_path: &Path) -> Result<Vec<PrComment>, Ap
 
     // Fetch inline review comments via API
     let api_path = format!("repos/{}/{}/pulls/{}/comments", owner, repo, pr_number);
-    let api_output = Command::new(&gh)
+    let api_output = platform::command(&gh)
         .args(["api", &api_path, "--paginate"])
         .current_dir(worktree_path)
         .output()
@@ -339,7 +339,7 @@ pub fn get_pr_review_comments(worktree_path: &Path) -> Result<Vec<PrComment>, Ap
 
 pub fn list_repo_prs(repo_path: &Path) -> Result<Vec<PrListItem>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "pr",
             "list",
@@ -406,7 +406,7 @@ pub fn list_repo_prs(repo_path: &Path) -> Result<Vec<PrListItem>, AppError> {
 
 pub fn get_pr_detail(repo_path: &Path, number: u32) -> Result<PrDetail, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "pr",
             "view",
@@ -465,7 +465,7 @@ pub fn get_pr_detail(repo_path: &Path, number: u32) -> Result<PrDetail, AppError
 
 pub fn list_repo_issues(repo_path: &Path) -> Result<Vec<IssueListItem>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "issue",
             "list",
@@ -527,7 +527,7 @@ pub fn list_repo_issues(repo_path: &Path) -> Result<Vec<IssueListItem>, AppError
 
 pub fn get_issue_detail(repo_path: &Path, number: u32) -> Result<IssueDetail, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "issue",
             "view",
@@ -580,7 +580,7 @@ pub fn get_issue_detail(repo_path: &Path, number: u32) -> Result<IssueDetail, Ap
 
 pub fn get_workflow_runs(worktree_path: &Path, branch: &str) -> Result<Vec<WorkflowRun>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args([
             "run",
             "list",
@@ -645,7 +645,7 @@ pub fn get_workflow_runs(worktree_path: &Path, branch: &str) -> Result<Vec<Workf
 
 pub fn get_run_jobs(worktree_path: &Path, run_id: u64) -> Result<Vec<WorkflowJob>, AppError> {
     let gh = find_gh_binary()?;
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["run", "view", &run_id.to_string(), "--json", "jobs"])
         .current_dir(worktree_path)
         .output()
@@ -721,7 +721,7 @@ pub fn get_run_logs(
 ) -> Result<RunLogsResult, AppError> {
     let gh = find_gh_binary()?;
     let log_flag = if failed_only { "--log-failed" } else { "--log" };
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(["run", "view", &run_id.to_string(), log_flag])
         .current_dir(worktree_path)
         .output()
@@ -762,7 +762,7 @@ pub fn rerun_workflow(
         args.push("--failed");
     }
 
-    let output = Command::new(&gh)
+    let output = platform::command(&gh)
         .args(&args)
         .current_dir(worktree_path)
         .output()

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
-use std::process::Command;
 
 use crate::error::AppError;
 use crate::models::mcp::{McpScope, McpServer};
+use crate::platform;
 use crate::services::claude_process;
 
 /// Get details for a single MCP server by name.
 fn get_mcp_server(claude: &std::path::Path, name: &str) -> Option<McpServer> {
-    let output = Command::new(claude)
+    let output = platform::command(claude)
         .args(["mcp", "get", name])
         .output()
         .ok()?;
@@ -66,7 +66,7 @@ fn get_mcp_server(claude: &std::path::Path, name: &str) -> Option<McpServer> {
 pub fn list_mcp_servers(_scope: &McpScope) -> Result<Vec<McpServer>, AppError> {
     let claude = claude_process::find_claude_binary()?;
 
-    let output = Command::new(&claude)
+    let output = platform::command(&claude)
         .args(["mcp", "list"])
         .output()
         .map_err(|e| AppError::McpError(format!("Failed to run claude mcp list: {}", e)))?;
@@ -134,7 +134,7 @@ pub fn add_mcp_server(
     cmd_args.push(command.to_string());
     cmd_args.extend(args.iter().cloned());
 
-    let output = Command::new(&claude)
+    let output = platform::command(&claude)
         .args(&cmd_args)
         .output()
         .map_err(|e| AppError::McpError(format!("Failed to run claude mcp add: {}", e)))?;
@@ -153,7 +153,7 @@ pub fn add_mcp_server(
 pub fn remove_mcp_server(name: &str, scope: &McpScope) -> Result<(), AppError> {
     let claude = claude_process::find_claude_binary()?;
 
-    let output = Command::new(&claude)
+    let output = platform::command(&claude)
         .args(["mcp", "remove", name, "-s", scope.as_str()])
         .output()
         .map_err(|e| AppError::McpError(format!("Failed to run claude mcp remove: {}", e)))?;

--- a/src-tauri/src/services/script_runner.rs
+++ b/src-tauri/src/services/script_runner.rs
@@ -88,7 +88,7 @@ pub async fn spawn_script(
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x00000200); // CREATE_NEW_PROCESS_GROUP
+        cmd.creation_flags(0x08000200); // CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
     }
 
     let mut child = cmd.spawn().map_err(|e| {

--- a/src-tauri/src/services/worktree.rs
+++ b/src-tauri/src/services/worktree.rs
@@ -1,6 +1,6 @@
 use crate::error::AppError;
+use crate::platform;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// Create an isolated git worktree for a workspace.
 pub fn create_worktree(
@@ -16,7 +16,7 @@ pub fn create_worktree(
     let worktree_path = worktree_base.join(&safe_name);
 
     // Check branch not already checked out
-    let existing = Command::new("git")
+    let existing = platform::command("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_path)
         .output()?;
@@ -27,7 +27,7 @@ pub fn create_worktree(
     }
 
     // Check if branch exists
-    let branch_exists = Command::new("git")
+    let branch_exists = platform::command("git")
         .args([
             "rev-parse",
             "--verify",
@@ -39,7 +39,7 @@ pub fn create_worktree(
         .success();
 
     let output = if branch_exists {
-        Command::new("git")
+        platform::command("git")
             .args([
                 "worktree",
                 "add",
@@ -59,7 +59,7 @@ pub fn create_worktree(
         if let Some(base) = base_branch {
             args.push(base.to_string());
         }
-        Command::new("git")
+        platform::command("git")
             .args(&args)
             .current_dir(repo_path)
             .output()?
@@ -76,7 +76,7 @@ pub fn create_worktree(
 
 /// Remove a git worktree.
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<(), AppError> {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args([
             "worktree",
             "remove",
@@ -92,7 +92,7 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<(), App
     }
 
     // Prune stale references
-    let _ = Command::new("git")
+    let _ = platform::command("git")
         .args(["worktree", "prune"])
         .current_dir(repo_path)
         .output();
@@ -102,12 +102,12 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<(), App
 
 /// Apply sparse checkout to restrict visible directories.
 pub fn apply_sparse_checkout(worktree_path: &Path, dirs: &[String]) -> Result<(), AppError> {
-    Command::new("git")
+    platform::command("git")
         .args(["sparse-checkout", "init", "--cone"])
         .current_dir(worktree_path)
         .output()?;
 
-    let mut cmd = Command::new("git");
+    let mut cmd = platform::command("git");
     cmd.arg("sparse-checkout").arg("set");
     for dir in dirs {
         cmd.arg(dir);
@@ -142,7 +142,7 @@ fn sanitize_name(name: &str) -> String {
 
 /// Detect the default branch of a repository.
 pub fn detect_default_branch(repo_path: &Path) -> String {
-    let output = Command::new("git")
+    let output = platform::command("git")
         .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
         .current_dir(repo_path)
         .output();
@@ -160,7 +160,7 @@ pub fn detect_default_branch(repo_path: &Path) -> String {
 
     // Fallback: check for common branch names
     for name in &["main", "master"] {
-        let check = Command::new("git")
+        let check = platform::command("git")
             .args(["rev-parse", "--verify", &format!("refs/heads/{}", name)])
             .current_dir(repo_path)
             .output();


### PR DESCRIPTION
## Summary
- Add `platform::command()` helper that sets `CREATE_NO_WINDOW` (0x08000000) on Windows
- Replace all bare `Command::new()` calls with `platform::command()` across 11 files
- Update long-running processes (Claude, Codex, Copilot, scripts) to use `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` (0x08000200)
- Fix `taskkill` in `platform/windows.rs` to also hide its console window

## Problem
Every spawned process (git, gh, formatters, taskkill, MCP commands) was causing a visible terminal window to flash on Windows. With PR check polling every 30 seconds spawning multiple git/gh calls, this was especially noticeable.

## Files changed
- `src-tauri/src/platform/mod.rs` — new `command()` helper + updated `configure_process_group`
- `src-tauri/src/platform/windows.rs` — `CREATE_NO_WINDOW` on taskkill
- `src-tauri/src/commands/git.rs` — git log, ls-tree, formatters
- `src-tauri/src/commands/repository.rs` — git rev-parse, branch, clone, init
- `src-tauri/src/commands/workspace.rs` — git fetch, sparse-checkout
- `src-tauri/src/services/branch.rs` — all git operations
- `src-tauri/src/services/checkpoint.rs` — all git operations
- `src-tauri/src/services/diff.rs` — git diff, ls-files, merge-base, show
- `src-tauri/src/services/gh.rs` — all gh CLI calls
- `src-tauri/src/services/mcp.rs` — claude CLI calls
- `src-tauri/src/services/worktree.rs` — git worktree operations
- `src-tauri/src/services/claude_process.rs` — 0x200 → 0x08000200
- `src-tauri/src/services/codex_process.rs` — 0x200 → 0x08000200
- `src-tauri/src/services/copilot_lsp.rs` — 0x200 → 0x08000200
- `src-tauri/src/services/script_runner.rs` — 0x200 → 0x08000200

## Test plan
- [x] `cargo check` passes
- [x] All 1737 unit tests pass
- [ ] Verify on Windows: no terminal windows flash during normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)