### PR TITLE
v1.4.1: Windows fixes and file tree caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fury"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fury"
-version = "1.4.0"
+version = "1.4.1"
 description = "Cross-platform coding agent orchestration"
 authors = ["Tyler Gray"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fury",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.fury.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/stores/fileTreeStore.test.ts
+++ b/src/stores/fileTreeStore.test.ts
@@ -30,6 +30,31 @@ describe("fileTreeStore - loadFiles", () => {
     expect(useFileTreeStore.getState().error["ws-1"]).toBe("Error: fail");
     expect(useFileTreeStore.getState().loading["ws-1"]).toBe(false);
   });
+
+  it("shows loading spinner on first load only", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["a.ts"]);
+    // First load: loading should be true
+    const promise1 = useFileTreeStore.getState().loadFiles("ws-1");
+    expect(useFileTreeStore.getState().loading["ws-1"]).toBe(true);
+    await promise1;
+
+    // Second load: loading should stay false (cached data shown)
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["a.ts", "b.ts"]);
+    const promise2 = useFileTreeStore.getState().loadFiles("ws-1");
+    expect(useFileTreeStore.getState().loading["ws-1"]).toBe(false);
+    await promise2;
+    expect(useFileTreeStore.getState().files["ws-1"]).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("suppresses error when cached data exists", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["a.ts"]);
+    await useFileTreeStore.getState().loadFiles("ws-1");
+
+    vi.mocked(listWorkspaceFiles).mockRejectedValue(new Error("network"));
+    await useFileTreeStore.getState().loadFiles("ws-1");
+    expect(useFileTreeStore.getState().error["ws-1"]).toBeNull();
+    expect(useFileTreeStore.getState().files["ws-1"]).toEqual(["a.ts"]);
+  });
 });
 
 describe("fileTreeStore - loadRepoFiles", () => {

--- a/src/stores/fileTreeStore.ts
+++ b/src/stores/fileTreeStore.ts
@@ -12,15 +12,16 @@ interface FileTreeStore {
   toggleDir: (contextId: string, dir: string) => void;
 }
 
-export const useFileTreeStore = create<FileTreeStore>((set) => ({
+export const useFileTreeStore = create<FileTreeStore>((set, get) => ({
   files: {},
   expandedDirs: {},
   loading: {},
   error: {},
 
   loadFiles: async (workspaceId: string) => {
+    const hasCached = workspaceId in get().files;
     set((state) => ({
-      loading: { ...state.loading, [workspaceId]: true },
+      loading: { ...state.loading, [workspaceId]: !hasCached },
       error: { ...state.error, [workspaceId]: null },
     }));
     try {
@@ -32,14 +33,15 @@ export const useFileTreeStore = create<FileTreeStore>((set) => ({
     } catch (e) {
       set((state) => ({
         loading: { ...state.loading, [workspaceId]: false },
-        error: { ...state.error, [workspaceId]: String(e) },
+        error: hasCached ? state.error : { ...state.error, [workspaceId]: String(e) },
       }));
     }
   },
 
   loadRepoFiles: async (repoId: string) => {
+    const hasCached = repoId in get().files;
     set((state) => ({
-      loading: { ...state.loading, [repoId]: true },
+      loading: { ...state.loading, [repoId]: !hasCached },
       error: { ...state.error, [repoId]: null },
     }));
     try {
@@ -51,7 +53,7 @@ export const useFileTreeStore = create<FileTreeStore>((set) => ({
     } catch (e) {
       set((state) => ({
         loading: { ...state.loading, [repoId]: false },
-        error: { ...state.error, [repoId]: String(e) },
+        error: hasCached ? state.error : { ...state.error, [repoId]: String(e) },
       }));
     }
   },


### PR DESCRIPTION
## Summary
- **Windows console fix** — All process spawns now use `CREATE_NO_WINDOW` (#38)
- **File tree caching** — "All files" tab shows cached data instantly, refreshes in background
- Errors suppressed on background refresh when cached data exists
- Version bump to 1.4.1

## Test plan
- [x] All 1739 tests pass
- [x] `cargo check` passes
- [ ] Verify on Windows: no terminal flashing, instant file tree on tab revisit

🤖 Generated with [Claude Code](https://claude.com/claude-code)