### PR TITLE
Add auto-update banner and fix updater config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fury",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fury",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dependencies": {
         "@github/copilot-language-server": "^1.430.0",
         "@monaco-editor/react": "^4",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/OWNER/fury/releases/latest/download/latest.json"
+        "https://github.com/tylergraydev/fury/releases/latest/download/latest.json"
       ],
       "pubkey": ""
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { clearSession, getAppSettings } from "./lib/tauri";
 import { useChatStore } from "./stores/chatStore";
 import { useCopilotStore } from "./stores/copilotStore";
 import { ToastContainer } from "./components/Toast";
+import { UpdateBanner } from "./components/UpdateBanner";
+import { useAutoUpdate } from "./lib/autoUpdate";
 import { applyTheme } from "./lib/themes";
 import "./App.css";
 
@@ -84,6 +86,7 @@ function App() {
   const theme = useUIStore((s) => s.theme);
   const [showPalette, setShowPalette] = useState(false);
   const [paletteMode, setPaletteMode] = useState<PaletteMode>("default");
+  const autoUpdate = useAutoUpdate();
 
   // Apply theme on mount and when it changes
   useEffect(() => {
@@ -206,7 +209,17 @@ function App() {
     const showSettingsOverlay = activeViewTabId === "settings";
 
     return (
-      <div className="h-screen">
+      <div className="h-screen flex flex-col">
+        {autoUpdate.update && (
+          <UpdateBanner
+            version={autoUpdate.update.version}
+            installing={autoUpdate.installing}
+            installed={autoUpdate.installed}
+            error={autoUpdate.error}
+            onInstall={autoUpdate.install}
+            onDismiss={autoUpdate.dismiss}
+          />
+        )}
         <LandingPage onOpenSettings={() => handleAction("open-settings")} />
 
         {showSettingsOverlay && (
@@ -247,7 +260,17 @@ function App() {
   const showRightSidebar = rightSidebarVisible && sidebarContext !== null;
 
   return (
-    <div className="h-screen">
+    <div className="h-screen flex flex-col">
+      {autoUpdate.update && (
+        <UpdateBanner
+          version={autoUpdate.update.version}
+          installing={autoUpdate.installing}
+          installed={autoUpdate.installed}
+          error={autoUpdate.error}
+          onInstall={autoUpdate.install}
+          onDismiss={autoUpdate.dismiss}
+        />
+      )}
       <PanelGroup direction="horizontal" key={showRightSidebar ? "with-right" : "without-right"}>
         <Panel defaultSize={20} minSize={12} maxSize={30}>
           <ErrorBoundary label="Sidebar">

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,75 @@
+import { Download, X, RotateCcw } from "lucide-react";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+interface UpdateBannerProps {
+  version: string;
+  installing: boolean;
+  installed: boolean;
+  error: string | null;
+  onInstall: () => void;
+  onDismiss: () => void;
+}
+
+export function UpdateBanner({
+  version,
+  installing,
+  installed,
+  error,
+  onInstall,
+  onDismiss,
+}: UpdateBannerProps) {
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-2 text-xs"
+      style={{
+        backgroundColor: "var(--accent)",
+        color: "var(--bg-primary)",
+      }}
+    >
+      <Download className="h-3.5 w-3.5 flex-shrink-0" />
+      <span className="flex-1">
+        {error
+          ? error
+          : installed
+            ? `Update v${version} installed. Restart to apply.`
+            : installing
+              ? "Downloading update..."
+              : `Update v${version} is available.`}
+      </span>
+
+      {installed ? (
+        <button
+          onClick={() => relaunch()}
+          className="flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium transition-opacity hover:opacity-80"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            color: "var(--accent)",
+          }}
+        >
+          <RotateCcw className="h-3 w-3" />
+          Restart
+        </button>
+      ) : !installing && !error ? (
+        <button
+          onClick={onInstall}
+          className="rounded px-2 py-0.5 text-xs font-medium transition-opacity hover:opacity-80"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            color: "var(--accent)",
+          }}
+        >
+          Install
+        </button>
+      ) : null}
+
+      {!installing && (
+        <button
+          onClick={onDismiss}
+          className="flex-shrink-0 rounded p-0.5 transition-opacity hover:opacity-70"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/AppSettingsPanel.test.tsx
+++ b/src/components/settings/AppSettingsPanel.test.tsx
@@ -1890,9 +1890,9 @@ describe("UpdatesTab", () => {
     fireEvent.click(screen.getByText("Updates"));
   };
 
-  it("shows current version", () => {
+  it("shows current version", async () => {
     goToUpdatesTab();
-    expect(screen.getByText("Current version: v0.1.0")).toBeInTheDocument();
+    expect(await screen.findByText("Current version: v1.4.1")).toBeInTheDocument();
   });
 
   it("shows Check for Updates button", () => {

--- a/src/components/settings/AppSettingsPanel.tsx
+++ b/src/components/settings/AppSettingsPanel.tsx
@@ -1372,6 +1372,14 @@ function ExperimentalTab() {
 function UpdatesTab() {
   const [checking, setChecking] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    import("@tauri-apps/api/app")
+      .then((mod) => mod.getVersion())
+      .then((v) => setAppVersion(v))
+      .catch(() => {});
+  }, []);
 
   const checkForUpdates = async () => {
     setChecking(true);
@@ -1409,7 +1417,7 @@ function UpdatesTab() {
           }}
         >
           <div className="mb-2 text-xs" style={{ color: "var(--text-primary)" }}>
-            Current version: v0.1.0
+            Current version: v{appVersion ?? "..."}
           </div>
           {status && (
             <div

--- a/src/lib/autoUpdate.ts
+++ b/src/lib/autoUpdate.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { Update } from "@tauri-apps/plugin-updater";
+import { getVersion } from "@tauri-apps/api/app";
+
+const UPDATE_CHECK_DELAY_MS = 5_000;
+
+interface AutoUpdateState {
+  update: Update | null;
+  checking: boolean;
+  installing: boolean;
+  installed: boolean;
+  error: string | null;
+}
+
+export function useAutoUpdate() {
+  const [state, setState] = useState<AutoUpdateState>({
+    update: null,
+    checking: false,
+    installing: false,
+    installed: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      setState((s) => ({ ...s, checking: true }));
+      try {
+        const { check } = await import("@tauri-apps/plugin-updater");
+        const update = await check();
+        setState((s) => ({ ...s, update: update ?? null, checking: false }));
+      } catch {
+        // Silently fail on startup - user can manually check in Settings
+        setState((s) => ({ ...s, checking: false }));
+      }
+    }, UPDATE_CHECK_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const install = async () => {
+    if (!state.update) return;
+    setState((s) => ({ ...s, installing: true, error: null }));
+    try {
+      await state.update.downloadAndInstall();
+      setState((s) => ({ ...s, installing: false, installed: true }));
+    } catch (e) {
+      setState((s) => ({
+        ...s,
+        installing: false,
+        error: `Install failed: ${e}`,
+      }));
+    }
+  };
+
+  const dismiss = () => {
+    setState((s) => ({ ...s, update: null }));
+  };
+
+  return { ...state, install, dismiss };
+}
+
+export async function getAppVersion(): Promise<string> {
+  try {
+    return await getVersion();
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -45,6 +45,12 @@ vi.mock("@tauri-apps/plugin-updater", () => ({
   check: vi.fn().mockResolvedValue(null),
 }));
 
+// Mock @tauri-apps/api/app
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("1.4.1"),
+  getName: vi.fn().mockResolvedValue("Fury"),
+}));
+
 // Mock @tauri-apps/api/path
 vi.mock("@tauri-apps/api/path", () => ({
   homeDir: vi.fn().mockResolvedValue("/home/user/"),


### PR DESCRIPTION
## Summary
- Adds a `useAutoUpdate` hook that silently checks for updates 5 seconds after app startup and exposes install/dismiss actions
- Adds an `UpdateBanner` component rendered at the top of the app when an update is available, with install, restart, and dismiss buttons
- Fixes the Tauri updater endpoint URL to point to `tylergraydev/fury` instead of the placeholder `OWNER/fury`
- Replaces the hardcoded "v0.1.0" in the Settings Updates tab with the real app version fetched from `@tauri-apps/api/app`

## Test plan
- [ ] Launch the app and verify no banner appears when already on the latest version
- [ ] Simulate an available update and verify the banner shows with correct version
- [ ] Click "Install" and verify download progress / "Downloading update..." state
- [ ] After install completes, verify "Restart" button appears and relaunches the app
- [ ] Click dismiss (X) and verify the banner hides
- [ ] Open Settings > Updates and verify the real app version is displayed
- [ ] Run existing tests (`npm test`) to confirm mocks and assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)