### PR TITLE
Bump version to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fury"
-version = "1.4.1"
+version = "1.5.0"
 description = "Cross-platform coding agent orchestration"
 authors = ["Tyler Gray"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fury",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "identifier": "com.fury.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bumps version from 1.4.1 to 1.5.0 in `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`
- Prepares for release containing: performance monitor, auto-updates, markdown rendering, stop button, UI lockup fixes, and test coverage improvements

## After merge
Tag `v1.5.0` on main and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)