### PR TITLE
Remove task description from New Chat Worktree dialog

### DIFF
--- a/e2e/tests/workspace-dialogs.spec.ts
+++ b/e2e/tests/workspace-dialogs.spec.ts
@@ -24,7 +24,7 @@ test.describe("Workspace Dialogs", () => {
     ).toBeVisible();
   });
 
-  test("task description textarea and worktree name input visible", async ({
+  test("worktree name input visible", async ({
     appPage,
   }) => {
     await appPage.getByText("add-auth").click();
@@ -38,44 +38,12 @@ test.describe("Workspace Dialogs", () => {
 
     const dialog = appPage.locator(".fixed.inset-0.z-50");
     await expect(dialog).toBeVisible();
-
-    // Task description
-    await expect(
-      dialog.getByText("What do you want to work on?"),
-    ).toBeVisible();
-    await expect(dialog.locator("textarea")).toBeVisible();
 
     // Worktree name input
     await expect(dialog.getByText("Worktree Name")).toBeVisible();
     await expect(
       dialog.locator('input[placeholder="feature-auth"]'),
     ).toBeVisible();
-  });
-
-  test("Generate button creates name from task description", async ({
-    appPage,
-  }) => {
-    await appPage.getByText("add-auth").click();
-    await expect(
-      appPage.getByText("/add-auth", { exact: true }),
-    ).toBeVisible();
-
-    await appPage
-      .locator("button", { hasText: "New Chat Worktree" })
-      .click();
-
-    const dialog = appPage.locator(".fixed.inset-0.z-50");
-    await expect(dialog).toBeVisible();
-
-    // Type a task description
-    await dialog.locator("textarea").fill("Add OAuth authentication flow");
-
-    // Click Generate
-    await dialog.locator("button", { hasText: "Generate" }).click();
-
-    // Worktree name should be auto-generated as kebab-case
-    const nameInput = dialog.locator('input[placeholder="feature-auth"]');
-    await expect(nameInput).toHaveValue("add-oauth-authentication-flow");
   });
 
   test("branch dropdown loads branches from mock", async ({ appPage }) => {

--- a/src/components/workspace/NewWorkspaceDialog.test.tsx
+++ b/src/components/workspace/NewWorkspaceDialog.test.tsx
@@ -70,13 +70,6 @@ describe("NewWorkspaceDialog", () => {
     expect(screen.getByText("my-repo")).toBeInTheDocument();
   });
 
-  it("has task description textarea", () => {
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
-    );
-    expect(screen.getByText("What do you want to work on?")).toBeInTheDocument();
-  });
-
   it("has auto-commit checkbox defaulting to checked", () => {
     render(
       <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
@@ -99,15 +92,6 @@ describe("NewWorkspaceDialog", () => {
     );
     expect(mockListBranches).toHaveBeenCalledWith("r1");
   });
-
-  it("has Generate button for worktree name", () => {
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
-    );
-    expect(screen.getByText("Generate")).toBeInTheDocument();
-  });
-
-  // --- New tests for full coverage ---
 
   it("populates branch dropdown with loaded branches", async () => {
     render(
@@ -188,47 +172,6 @@ describe("NewWorkspaceDialog", () => {
     const select = screen.getByRole("combobox");
     fireEvent.change(select, { target: { value: "dev" } });
     expect((select as HTMLSelectElement).value).toBe("dev");
-  });
-
-  it("updates task description textarea", () => {
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
-    );
-    const textarea = screen.getByPlaceholderText(/Add OAuth authentication/);
-    fireEvent.change(textarea, { target: { value: "Fix the login bug" } });
-    expect(textarea).toHaveValue("Fix the login bug");
-  });
-
-  it("generates worktree name from task description", () => {
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
-    );
-    const textarea = screen.getByPlaceholderText(/Add OAuth authentication/);
-    fireEvent.change(textarea, { target: { value: "Add OAuth Authentication!" } });
-
-    fireEvent.click(screen.getByText("Generate"));
-
-    const nameInput = screen.getByPlaceholderText("feature-auth");
-    expect(nameInput).toHaveValue("add-oauth-authentication");
-  });
-
-  it("Generate button does not update name when task description is empty", () => {
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={vi.fn()} />,
-    );
-    const generateBtn = screen.getByText("Generate").closest("button")!;
-    expect(generateBtn).toBeDisabled();
-
-    // Directly invoke the onClick handler via React fiber to bypass the disabled button check,
-    // exercising the if-guard false branch when taskDescription is empty.
-    const fiber = Object.keys(generateBtn).find(k => k.startsWith("__reactFiber"));
-    const onClick = fiber ? (generateBtn as any)[fiber]?.memoizedProps?.onClick : null;
-    expect(onClick).toBeDefined();
-    onClick();
-
-    // Worktree name should still be empty
-    const nameInput = screen.getByPlaceholderText("feature-auth");
-    expect(nameInput).toHaveValue("");
   });
 
   it("allows manual worktree name input", () => {
@@ -325,29 +268,6 @@ describe("NewWorkspaceDialog", () => {
       expect(mockCreateWs).toHaveBeenCalledWith(
         expect.objectContaining({ autoCommit: false }),
       );
-    });
-  });
-
-  it("sends task description as first message when provided", async () => {
-    const onClose = vi.fn();
-    render(
-      <NewWorkspaceDialog repoId="r1" repoName="my-repo" onClose={onClose} />,
-    );
-    await waitFor(() => {
-      const select = screen.getByRole("combobox");
-      expect(select).not.toBeDisabled();
-    });
-
-    const textarea = screen.getByPlaceholderText(/Add OAuth authentication/);
-    fireEvent.change(textarea, { target: { value: "Fix the login issue" } });
-
-    const nameInput = screen.getByPlaceholderText("feature-auth");
-    fireEvent.change(nameInput, { target: { value: "fix-login" } });
-
-    fireEvent.click(screen.getByText("Create & Start Chat"));
-
-    await waitFor(() => {
-      expect(mockSendMsg).toHaveBeenCalledWith("ws-new", "Fix the login issue");
     });
   });
 
@@ -451,8 +371,7 @@ describe("NewWorkspaceDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("handles sendMessage failure gracefully (non-blocking)", async () => {
-    mockSendMsg.mockRejectedValueOnce(new Error("Send failed"));
+  it("does not send message in branch mode (no task description)", async () => {
     const onClose = vi.fn();
 
     render(
@@ -463,18 +382,15 @@ describe("NewWorkspaceDialog", () => {
       expect(select).not.toBeDisabled();
     });
 
-    const textarea = screen.getByPlaceholderText(/Add OAuth authentication/);
-    fireEvent.change(textarea, { target: { value: "Do something" } });
-
     const nameInput = screen.getByPlaceholderText("feature-auth");
     fireEvent.change(nameInput, { target: { value: "my-ws" } });
 
     fireEvent.click(screen.getByText("Create & Start Chat"));
 
-    // Even if sendMessage fails, onClose should still be called
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
     });
+    expect(mockSendMsg).not.toHaveBeenCalled();
   });
 
   it("shows Loading... in branch dropdown while loading", () => {

--- a/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/src/components/workspace/NewWorkspaceDialog.tsx
@@ -3,7 +3,6 @@ import {
   Sparkles,
   X,
   GitFork,
-  MessageSquare,
   ChevronDown,
   GitPullRequest,
   CircleDot,
@@ -623,34 +622,6 @@ export function NewWorkspaceDialog({ repoId, repoName, onClose }: Props) {
           </div>
         )}
 
-        {/* Task description */}
-        <div className="mb-4">
-          <label
-            className="mb-1.5 flex items-center gap-1.5 text-xs"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-            What do you want to work on?
-          </label>
-          <textarea
-            value={taskDescription}
-            onChange={(e) => setTaskDescription(e.target.value)}
-            placeholder="e.g., Add OAuth authentication, Refactor the API layer, Fix database migrations..."
-            rows={3}
-            className="w-full resize-none rounded-lg px-3 py-2.5 text-xs"
-            style={inputStyle}
-            autoFocus={mode === "branch"}
-          />
-          <p
-            className="mt-1 text-[11px]"
-            style={{ color: "var(--text-muted)" }}
-          >
-            {mode === "pr" || mode === "issue" || mode === "linear"
-              ? "Auto-filled from selection. Edit to customize the initial message."
-              : "This helps the AI understand the context and will be used to name your worktree"}
-          </p>
-        </div>
-
         {/* Worktree Name */}
         <div className="mb-4">
           <label
@@ -659,45 +630,21 @@ export function NewWorkspaceDialog({ repoId, repoName, onClose }: Props) {
           >
             Worktree Name
           </label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={worktreeName}
-              onChange={(e) => setWorktreeName(e.target.value)}
-              placeholder="feature-auth"
-              className="flex-1 rounded-lg px-3 py-2 text-xs"
-              style={{
-                ...inputStyle,
-                ...(mode === "pr"
-                  ? { opacity: 0.7, cursor: "default" }
-                  : {}),
-              }}
-              readOnly={mode === "pr"}
-            />
-            {mode === "branch" && (
-              <button
-                onClick={() => {
-                  /* v8 ignore next -- @preserve */
-                  if (taskDescription.trim()) {
-                    setWorktreeName(generateName(taskDescription));
-                  }
-                }}
-                disabled={!taskDescription.trim()}
-                className="rounded-lg px-4 py-2 text-xs font-medium transition-colors"
-                style={{
-                  backgroundColor: taskDescription.trim()
-                    ? "var(--accent)"
-                    : "var(--bg-surface)",
-                  color: taskDescription.trim()
-                    ? "#1e1e2e"
-                    : "var(--text-muted)",
-                  border: "1px solid var(--border)",
-                }}
-              >
-                Generate
-              </button>
-            )}
-          </div>
+          <input
+            type="text"
+            value={worktreeName}
+            onChange={(e) => setWorktreeName(e.target.value)}
+            placeholder="feature-auth"
+            className="w-full rounded-lg px-3 py-2 text-xs"
+            style={{
+              ...inputStyle,
+              ...(mode === "pr"
+                ? { opacity: 0.7, cursor: "default" }
+                : {}),
+            }}
+            readOnly={mode === "pr"}
+            autoFocus={mode === "branch"}
+          />
         </div>
 
         {/* Base Branch */}


### PR DESCRIPTION
## Summary
- Removed the "What do you want to work on?" textarea and Generate button from the New Chat Worktree dialog
- Users now directly enter a worktree name, simplifying the creation flow
- Task descriptions are still auto-filled and sent as first messages when creating from PR, issue, or Linear modes

## Test plan
- [ ] Open New Chat Worktree dialog and verify textarea and Generate button are gone
- [ ] Verify worktree name input is auto-focused in branch mode
- [ ] Create a workspace from PR/issue/Linear mode and verify first message is still sent
- [ ] Run unit tests: `npx vitest run src/components/workspace/NewWorkspaceDialog.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)