### PR TITLE
Add test coverage for components, hooks, and stores (Roadmap #19)

### DIFF
--- a/src/components/chat/ChatSearch.test.tsx
+++ b/src/components/chat/ChatSearch.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ChatSearch } from "./ChatSearch";
+
+vi.mock("../../lib/tauri", () => ({
+  searchChatMessages: vi.fn(),
+}));
+
+import { searchChatMessages } from "../../lib/tauri";
+import type { ChatMessageSearchResult } from "../../lib/tauri";
+
+function makeResult(overrides: Partial<ChatMessageSearchResult> = {}): ChatMessageSearchResult {
+  return {
+    messageId: "msg-1",
+    workspaceId: "ws-1",
+    workspaceName: "My Workspace",
+    role: "user",
+    matchedText: "hello world",
+    timestamp: "2025-06-15T10:30:00Z",
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  contextId: "ctx-1",
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function typeAndSearch(input: HTMLElement, text: string) {
+  await userEvent.type(input, text);
+  await act(async () => {
+    vi.advanceTimersByTime(300);
+  });
+  // Flush microtasks for the async search callback
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("ChatSearch", () => {
+  it("shows placeholder text when query is empty", () => {
+    render(<ChatSearch {...defaultProps} />);
+    expect(screen.getByText("Type to search conversation history")).toBeTruthy();
+  });
+
+  it("calls searchChatMessages after 300ms debounce", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "hello");
+
+    expect(searchChatMessages).toHaveBeenCalledWith("hello", "ctx-1");
+  });
+
+  it("shows No results found when search returns empty array", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "nothing");
+
+    await waitFor(() => {
+      expect(screen.getByText("No results found")).toBeTruthy();
+    });
+  });
+
+  it("renders search results with matched text", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([
+      makeResult({ matchedText: "result one" }),
+      makeResult({ messageId: "msg-2", matchedText: "result two" }),
+    ]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "result");
+
+    await waitFor(() => {
+      expect(screen.getByText("result one")).toBeTruthy();
+      expect(screen.getByText("result two")).toBeTruthy();
+    });
+  });
+
+  it("clicking result calls onNavigate with messageId", async () => {
+    const onNavigate = vi.fn();
+    vi.mocked(searchChatMessages).mockResolvedValue([makeResult()]);
+    render(<ChatSearch {...defaultProps} onNavigate={onNavigate} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "hello");
+
+    await waitFor(() => {
+      expect(screen.getByText("hello world")).toBeTruthy();
+    });
+
+    await userEvent.click(screen.getByText("hello world"));
+    expect(onNavigate).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("Search all workspaces checkbox passes undefined contextId", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const checkbox = screen.getByRole("checkbox");
+    await userEvent.click(checkbox);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "test");
+
+    expect(searchChatMessages).toHaveBeenCalledWith("test", undefined);
+  });
+
+  it("Escape key calls onClose", () => {
+    const onClose = vi.fn();
+    render(<ChatSearch {...defaultProps} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Search messages..."), {
+      key: "Escape",
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("close button calls onClose", async () => {
+    const onClose = vi.fn();
+    render(<ChatSearch {...defaultProps} onClose={onClose} />);
+
+    await userEvent.click(screen.getByTitle("Close"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("handles searchChatMessages error gracefully", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(searchChatMessages).mockRejectedValue(new Error("db error"));
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "test");
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+    expect(screen.getByText("No results found")).toBeTruthy();
+    spy.mockRestore();
+  });
+
+  it("debounce resets on rapid typing", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await userEvent.type(input, "h");
+    vi.advanceTimersByTime(100);
+    await userEvent.type(input, "e");
+    vi.advanceTimersByTime(100);
+    await userEvent.type(input, "l");
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(searchChatMessages).toHaveBeenCalledTimes(1);
+    expect(searchChatMessages).toHaveBeenCalledWith("hel", "ctx-1");
+  });
+
+  it("clears results when query is emptied", async () => {
+    vi.mocked(searchChatMessages).mockResolvedValue([makeResult()]);
+    render(<ChatSearch {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Search messages...");
+    await typeAndSearch(input, "test");
+
+    await waitFor(() => {
+      expect(screen.getByText("hello world")).toBeTruthy();
+    });
+
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(screen.getByText("Type to search conversation history")).toBeTruthy();
+    });
+  });
+});

--- a/src/components/file-viewer/BookmarkNoteDialog.test.tsx
+++ b/src/components/file-viewer/BookmarkNoteDialog.test.tsx
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BookmarkNoteDialog } from "./BookmarkNoteDialog";
+import { useBookmarkStore } from "../../stores/bookmarkStore";
+import type { FileBookmark } from "../../lib/tauri";
+
+vi.mock("../../lib/tauri", () => ({
+  listBookmarks: vi.fn(),
+  createBookmark: vi.fn(),
+  updateBookmark: vi.fn(),
+  deleteBookmark: vi.fn(),
+  toggleBookmark: vi.fn(),
+}));
+
+function makeBookmark(overrides: Partial<FileBookmark> = {}): FileBookmark {
+  return {
+    id: "bm-1",
+    repoId: "repo-1",
+    filePath: "src/index.ts",
+    lineNumber: 10,
+    note: null,
+    color: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBookmarkStore.setState({
+    bookmarks: {},
+    loading: {},
+    error: {},
+    editingBookmark: null,
+  });
+  vi.clearAllMocks();
+});
+
+describe("BookmarkNoteDialog", () => {
+  it("returns null when editingBookmark is null", () => {
+    const { container } = render(<BookmarkNoteDialog />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders Add Bookmark title for new bookmark", () => {
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+    });
+    render(<BookmarkNoteDialog />);
+    expect(screen.getByText("Add Bookmark")).toBeTruthy();
+  });
+
+  it("renders Edit Bookmark title for existing bookmark", () => {
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+        existing: makeBookmark(),
+      },
+    });
+    render(<BookmarkNoteDialog />);
+    expect(screen.getByText("Edit Bookmark")).toBeTruthy();
+  });
+
+  it("shows file name and line number", () => {
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/utils/helpers.ts",
+        lineNumber: 42,
+      },
+    });
+    render(<BookmarkNoteDialog />);
+    expect(screen.getByText("helpers.ts : Line 42")).toBeTruthy();
+  });
+
+  it("pre-fills note and color from existing bookmark", () => {
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+        existing: makeBookmark({ note: "important", color: "red" }),
+      },
+    });
+    render(<BookmarkNoteDialog />);
+    const input = screen.getByPlaceholderText("Add a note...") as HTMLInputElement;
+    expect(input.value).toBe("important");
+    // Red color button should have selected border
+    const redButton = screen.getByTitle("red");
+    expect(redButton.style.border).toContain("var(--text-primary)");
+  });
+
+  it("defaults to empty note and blue color for new bookmark", () => {
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+    });
+    render(<BookmarkNoteDialog />);
+    const input = screen.getByPlaceholderText("Add a note...") as HTMLInputElement;
+    expect(input.value).toBe("");
+    const blueButton = screen.getByTitle("blue");
+    expect(blueButton.style.border).toContain("var(--text-primary)");
+  });
+
+  it("clicking color button changes selected color", async () => {
+    const user = userEvent.setup();
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByTitle("green"));
+
+    expect(screen.getByTitle("green").style.border).toContain("var(--text-primary)");
+    expect(screen.getByTitle("blue").style.border).toContain("transparent");
+  });
+
+  it("Save calls addBookmark for new bookmark", async () => {
+    const user = userEvent.setup();
+    const addBookmark = vi.fn().mockResolvedValue(makeBookmark());
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      addBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByText("Save"));
+
+    expect(addBookmark).toHaveBeenCalledWith({
+      repoId: "repo-1",
+      filePath: "src/index.ts",
+      lineNumber: 10,
+      note: undefined,
+      color: "blue",
+    });
+  });
+
+  it("Save calls editBookmark for existing bookmark", async () => {
+    const user = userEvent.setup();
+    const editBookmark = vi.fn().mockResolvedValue(undefined);
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+        existing: makeBookmark({ id: "bm-1", note: "old" }),
+      },
+      editBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByText("Save"));
+
+    expect(editBookmark).toHaveBeenCalledWith("repo-1", "bm-1", {
+      note: "old",
+      color: "blue",
+    });
+  });
+
+  it("Save closes dialog", async () => {
+    const user = userEvent.setup();
+    const setEditingBookmark = vi.fn();
+    const addBookmark = vi.fn().mockResolvedValue(makeBookmark());
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      addBookmark,
+      setEditingBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByText("Save"));
+
+    expect(setEditingBookmark).toHaveBeenCalledWith(null);
+  });
+
+  it("Cancel closes dialog", async () => {
+    const user = userEvent.setup();
+    const setEditingBookmark = vi.fn();
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      setEditingBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByText("Cancel"));
+
+    expect(setEditingBookmark).toHaveBeenCalledWith(null);
+  });
+
+  it("Escape key closes dialog", () => {
+    const setEditingBookmark = vi.fn();
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      setEditingBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Add a note..."), {
+      key: "Escape",
+    });
+
+    expect(setEditingBookmark).toHaveBeenCalledWith(null);
+  });
+
+  it("Enter key triggers save", () => {
+    const addBookmark = vi.fn().mockResolvedValue(makeBookmark());
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      addBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Add a note..."), {
+      key: "Enter",
+    });
+
+    expect(addBookmark).toHaveBeenCalled();
+  });
+
+  it("passes note as undefined when empty string", async () => {
+    const user = userEvent.setup();
+    const addBookmark = vi.fn().mockResolvedValue(makeBookmark());
+    useBookmarkStore.setState({
+      editingBookmark: {
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      },
+      addBookmark,
+    });
+    render(<BookmarkNoteDialog />);
+
+    await user.click(screen.getByText("Save"));
+
+    expect(addBookmark).toHaveBeenCalledWith(
+      expect.objectContaining({ note: undefined }),
+    );
+  });
+});

--- a/src/components/notifications/NotificationBell.test.tsx
+++ b/src/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NotificationBell } from "./NotificationBell";
+import { useNotificationStore } from "../../stores/notificationStore";
+
+beforeEach(() => {
+  useNotificationStore.setState({
+    notifications: [],
+    unreadCount: 0,
+    panelOpen: false,
+  });
+});
+
+describe("NotificationBell", () => {
+  it("renders bell button", () => {
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-bell")).toBeTruthy();
+  });
+
+  it("shows no badge when unreadCount is 0", () => {
+    render(<NotificationBell />);
+    expect(screen.queryByTestId("notification-badge")).toBeNull();
+  });
+
+  it("shows badge with count when unreadCount > 0", () => {
+    useNotificationStore.setState({ unreadCount: 5 });
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-badge").textContent).toBe("5");
+  });
+
+  it("shows 99+ when unreadCount > 99", () => {
+    useNotificationStore.setState({ unreadCount: 150 });
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-badge").textContent).toBe("99+");
+  });
+
+  it("shows exact count at 99", () => {
+    useNotificationStore.setState({ unreadCount: 99 });
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-badge").textContent).toBe("99");
+  });
+
+  it("clicking button calls togglePanel", async () => {
+    const user = userEvent.setup();
+    const togglePanel = vi.fn();
+    useNotificationStore.setState({ togglePanel });
+
+    render(<NotificationBell />);
+    await user.click(screen.getByTestId("notification-bell"));
+
+    expect(togglePanel).toHaveBeenCalled();
+  });
+
+  it("has correct title attribute", () => {
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-bell").title).toBe("Notifications");
+  });
+});

--- a/src/components/notifications/NotificationPanel.test.tsx
+++ b/src/components/notifications/NotificationPanel.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NotificationPanel } from "./NotificationPanel";
+import { useNotificationStore, type Notification, type NotificationType } from "../../stores/notificationStore";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import { useUIStore } from "../../stores/uiStore";
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: "n-1",
+    type: "agent-complete" as NotificationType,
+    title: "Agent finished",
+    message: "Task completed successfully",
+    timestamp: Date.now() - 30 * 1000, // 30 seconds ago → "just now"
+    workspaceId: "ws-1",
+    workspaceName: "My Workspace",
+    read: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useNotificationStore.setState({
+    notifications: [],
+    unreadCount: 0,
+    panelOpen: false,
+  });
+  useWorkspaceStore.setState({
+    workspaces: [],
+    activeWorkspaceId: null,
+  });
+  vi.clearAllMocks();
+});
+
+describe("NotificationPanel", () => {
+  it("returns null when panel is closed", () => {
+    const { container } = render(<NotificationPanel />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders panel when open", () => {
+    useNotificationStore.setState({ panelOpen: true });
+    render(<NotificationPanel />);
+    expect(screen.getByTestId("notification-panel")).toBeTruthy();
+  });
+
+  it("shows No notifications when empty", () => {
+    useNotificationStore.setState({ panelOpen: true, notifications: [] });
+    render(<NotificationPanel />);
+    expect(screen.getByText("No notifications")).toBeTruthy();
+  });
+
+  it("renders grouped notifications with time labels", () => {
+    const now = Date.now();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [
+        makeNotification({ id: "n-1", timestamp: now - 60 * 1000 }), // Just now (<5 min)
+        makeNotification({ id: "n-2", timestamp: now - 3 * 60 * 60 * 1000 }), // Today
+      ],
+    });
+    render(<NotificationPanel />);
+
+    expect(screen.getByText("Just now")).toBeTruthy();
+    expect(screen.getByText("Today")).toBeTruthy();
+  });
+
+  it("shows Mark all read when unreadCount > 0", () => {
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification()],
+      unreadCount: 3,
+    });
+    render(<NotificationPanel />);
+    expect(screen.getByText("Mark all read")).toBeTruthy();
+  });
+
+  it("hides Mark all read when unreadCount is 0", () => {
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification({ read: true })],
+      unreadCount: 0,
+    });
+    render(<NotificationPanel />);
+    expect(screen.queryByText("Mark all read")).toBeNull();
+  });
+
+  it("Mark all read button calls markAllRead", async () => {
+    const user = userEvent.setup();
+    const markAllRead = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification()],
+      unreadCount: 1,
+      markAllRead,
+    });
+    render(<NotificationPanel />);
+
+    await user.click(screen.getByText("Mark all read"));
+    expect(markAllRead).toHaveBeenCalled();
+  });
+
+  it("Clear button calls clearAll", async () => {
+    const user = userEvent.setup();
+    const clearAll = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification()],
+      unreadCount: 0,
+      clearAll,
+    });
+    render(<NotificationPanel />);
+
+    await user.click(screen.getByText("Clear"));
+    expect(clearAll).toHaveBeenCalled();
+  });
+
+  it("Close button calls closePanel", async () => {
+    const user = userEvent.setup();
+    const closePanel = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [],
+      closePanel,
+    });
+    render(<NotificationPanel />);
+
+    // The X close button
+    const buttons = screen.getAllByRole("button");
+    const closeBtn = buttons.find(
+      (b) => b.querySelector("svg") && !b.textContent,
+    );
+    await user.click(closeBtn!);
+    expect(closePanel).toHaveBeenCalled();
+  });
+
+  it("clicking notification navigates to workspace", async () => {
+    const user = userEvent.setup();
+    const setActive = vi.fn();
+    useWorkspaceStore.setState({ setActive } as any);
+    const markRead = vi.fn();
+    const closePanel = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification()],
+      unreadCount: 1,
+      markRead,
+      closePanel,
+    });
+    render(<NotificationPanel />);
+
+    await user.click(screen.getByText("Agent finished"));
+    expect(setActive).toHaveBeenCalledWith("ws-1");
+    expect(markRead).toHaveBeenCalledWith("n-1");
+    expect(closePanel).toHaveBeenCalled();
+  });
+
+  it("clicking notification with navigateTo opens sidebar tab", async () => {
+    const user = userEvent.setup();
+    const setActive = vi.fn();
+    useWorkspaceStore.setState({ setActive } as any);
+    const setRightSidebarTab = vi.fn();
+    const ensureRightSidebarVisible = vi.fn();
+    useUIStore.setState({ setRightSidebarTab, ensureRightSidebarVisible } as any);
+    const markRead = vi.fn();
+    const closePanel = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [
+        makeNotification({
+          navigateTo: { rightSidebarTab: "test-runner" as any },
+        }),
+      ],
+      unreadCount: 1,
+      markRead,
+      closePanel,
+    });
+    render(<NotificationPanel />);
+
+    await user.click(screen.getByText("Agent finished"));
+    expect(setRightSidebarTab).toHaveBeenCalledWith("test-runner");
+    expect(ensureRightSidebarVisible).toHaveBeenCalled();
+  });
+
+  it("shows unread dot for unread notifications", () => {
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [makeNotification({ read: false })],
+      unreadCount: 1,
+    });
+    render(<NotificationPanel />);
+    // The unread dot is a span with rounded-full class inside the notification button
+    const dots = document.querySelectorAll("span.rounded-full");
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  it("click outside closes panel", () => {
+    const closePanel = vi.fn();
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [],
+      closePanel,
+    });
+    render(<NotificationPanel />);
+
+    fireEvent.mouseDown(document.body);
+    expect(closePanel).toHaveBeenCalled();
+  });
+
+  it("renders relative time for notifications", () => {
+    useNotificationStore.setState({
+      panelOpen: true,
+      notifications: [
+        makeNotification({ timestamp: Date.now() - 10 * 1000 }),
+      ],
+      unreadCount: 1,
+    });
+    render(<NotificationPanel />);
+    expect(screen.getByText("just now")).toBeTruthy();
+  });
+});

--- a/src/components/sidebar/BookmarksPanel.test.tsx
+++ b/src/components/sidebar/BookmarksPanel.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FileBookmark } from "../../lib/tauri";
+
+vi.mock("../../lib/tauri", () => ({
+  listBookmarks: vi.fn(),
+  createBookmark: vi.fn(),
+  updateBookmark: vi.fn(),
+  deleteBookmark: vi.fn(),
+  toggleBookmark: vi.fn(),
+}));
+
+// Mock fns accessible both inside vi.mock and in tests
+const { openFile, setRevealLine, loadBookmarks, setEditingBookmark, removeBookmark, setActiveViewTab } = vi.hoisted(() => ({
+  openFile: vi.fn(),
+  setRevealLine: vi.fn(),
+  loadBookmarks: vi.fn(),
+  setEditingBookmark: vi.fn(),
+  removeBookmark: vi.fn(),
+  setActiveViewTab: vi.fn(),
+}));
+
+// Store values that can be changed per-test
+let bookmarkStoreValues: Record<string, any> = {};
+let workspaceStoreValues: Record<string, any> = {};
+
+vi.mock("../../stores/bookmarkStore", () => ({
+  useBookmarkStore: Object.assign(
+    (selector: any) => {
+      const state = {
+        bookmarks: {},
+        loading: {},
+        error: {},
+        editingBookmark: null,
+        loadBookmarks,
+        setEditingBookmark,
+        removeBookmark,
+        ...bookmarkStoreValues,
+      };
+      return typeof selector === "function" ? selector(state) : state;
+    },
+    {
+      getState: () => ({
+        loadBookmarks,
+        setEditingBookmark,
+        removeBookmark,
+        ...bookmarkStoreValues,
+      }),
+    },
+  ),
+}));
+
+vi.mock("../../stores/fileViewerStore", () => ({
+  useFileViewerStore: Object.assign(
+    (selector: any) => {
+      const state = { tabs: {}, openFile, setRevealLine };
+      return typeof selector === "function" ? selector(state) : state;
+    },
+    { getState: () => ({ openFile, setRevealLine }) },
+  ),
+}));
+
+vi.mock("../../stores/workspaceStore", () => ({
+  useWorkspaceStore: (selector: any) => {
+    const state = {
+      workspaces: [{ id: "ws-1", repoId: "repo-1", name: "My Workspace" }],
+      ...workspaceStoreValues,
+    };
+    return typeof selector === "function" ? selector(state) : state;
+  },
+}));
+
+vi.mock("../../stores/uiStore", () => ({
+  useUIStore: Object.assign(
+    (selector: any) => {
+      const state = { setActiveViewTab };
+      return typeof selector === "function" ? selector(state) : state;
+    },
+    { getState: () => ({ setActiveViewTab }) },
+  ),
+}));
+
+import { BookmarksPanel } from "./BookmarksPanel";
+
+function makeBookmark(overrides: Partial<FileBookmark> = {}): FileBookmark {
+  return {
+    id: "bm-1",
+    repoId: "repo-1",
+    filePath: "src/index.ts",
+    lineNumber: 10,
+    note: null,
+    color: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  bookmarkStoreValues = {};
+  workspaceStoreValues = {};
+  vi.clearAllMocks();
+});
+
+describe("BookmarksPanel", () => {
+  it("shows loading state", () => {
+    bookmarkStoreValues = { loading: { "repo-1": true } };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+    expect(screen.getByText("Loading bookmarks...")).toBeTruthy();
+  });
+
+  it("shows empty state when no bookmarks", () => {
+    bookmarkStoreValues = { bookmarks: { "repo-1": [] } };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+    expect(screen.getByText("No bookmarks yet")).toBeTruthy();
+  });
+
+  it("renders bookmarks grouped by file", () => {
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [
+          makeBookmark({ id: "bm-1", filePath: "src/a.ts", lineNumber: 1 }),
+          makeBookmark({ id: "bm-2", filePath: "src/b.ts", lineNumber: 5 }),
+          makeBookmark({ id: "bm-3", filePath: "src/a.ts", lineNumber: 20 }),
+        ],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    expect(screen.getByText("a.ts")).toBeTruthy();
+    expect(screen.getByText("b.ts")).toBeTruthy();
+  });
+
+  it("sorts groups alphabetically by file path", () => {
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [
+          makeBookmark({ id: "bm-1", filePath: "src/z.ts", lineNumber: 1 }),
+          makeBookmark({ id: "bm-2", filePath: "src/a.ts", lineNumber: 1 }),
+        ],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    const headers = screen.getAllByText(/\.ts$/);
+    expect(headers[0].textContent).toBe("a.ts");
+    expect(headers[1].textContent).toBe("z.ts");
+  });
+
+  it("sorts bookmarks within group by line number", () => {
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [
+          makeBookmark({ id: "bm-1", filePath: "src/a.ts", lineNumber: 20 }),
+          makeBookmark({ id: "bm-2", filePath: "src/a.ts", lineNumber: 5 }),
+        ],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    const lineLabels = screen.getAllByText(/^L\d+$/);
+    expect(lineLabels[0].textContent).toBe("L5");
+    expect(lineLabels[1].textContent).toBe("L20");
+  });
+
+  it("shows bookmark count badge per file group", () => {
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [
+          makeBookmark({ id: "bm-1", filePath: "src/a.ts", lineNumber: 1 }),
+          makeBookmark({ id: "bm-2", filePath: "src/a.ts", lineNumber: 5 }),
+        ],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("clicking bookmark opens file and sets reveal line", async () => {
+    const user = userEvent.setup();
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [makeBookmark({ lineNumber: 42 })],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    await user.click(screen.getByText("L42"));
+
+    expect(openFile).toHaveBeenCalledWith("ws-1", "workspace", "src/index.ts", true);
+    expect(setRevealLine).toHaveBeenCalledWith("ws-1:src/index.ts", 42);
+    expect(setActiveViewTab).toHaveBeenCalledWith("chat");
+  });
+
+  it("edit button calls setEditingBookmark", async () => {
+    const user = userEvent.setup();
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [makeBookmark()],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    await user.click(screen.getByTitle("Edit bookmark"));
+    expect(setEditingBookmark).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      }),
+    );
+  });
+
+  it("delete button calls removeBookmark", async () => {
+    const user = userEvent.setup();
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [makeBookmark({ id: "bm-1" })],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    await user.click(screen.getByTitle("Delete bookmark"));
+    expect(removeBookmark).toHaveBeenCalledWith("repo-1", "bm-1");
+  });
+
+  it("resolves repoId from workspace context", () => {
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+    expect(loadBookmarks).toHaveBeenCalledWith("repo-1");
+  });
+
+  it("uses context.id directly for repo context", () => {
+    render(<BookmarksPanel context={{ type: "repo", id: "repo-42" }} />);
+    expect(loadBookmarks).toHaveBeenCalledWith("repo-42");
+  });
+
+  it("displays note text or No note italic fallback", () => {
+    bookmarkStoreValues = {
+      bookmarks: {
+        "repo-1": [
+          makeBookmark({ id: "bm-1", note: "important logic" }),
+          makeBookmark({ id: "bm-2", note: null, lineNumber: 20 }),
+        ],
+      },
+    };
+    render(<BookmarksPanel context={{ type: "workspace", id: "ws-1" }} />);
+
+    expect(screen.getByText("important logic")).toBeTruthy();
+    expect(screen.getByText("No note")).toBeTruthy();
+  });
+});

--- a/src/components/test-runner/TestConfigDialog.test.tsx
+++ b/src/components/test-runner/TestConfigDialog.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestConfigDialog } from "./TestConfigDialog";
+import { useTestRunnerStore } from "../../stores/testRunnerStore";
+
+vi.mock("../../lib/tauri", () => ({
+  runTests: vi.fn(),
+  stopTests: vi.fn(),
+  getTestRunnerConfig: vi.fn(),
+  detectTestFramework: vi.fn(),
+  saveTestRunnerConfig: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+const CTX = "ctx-1";
+const REPO = "repo-1";
+
+const saveConfig = vi.fn().mockResolvedValue(undefined);
+const loadConfig = vi.fn().mockResolvedValue(undefined);
+const detectFramework = vi.fn().mockResolvedValue(undefined);
+const onClose = vi.fn();
+
+beforeEach(() => {
+  useTestRunnerStore.setState({
+    config: {},
+    saveConfig,
+    loadConfig,
+    detectFramework,
+  } as any);
+  vi.clearAllMocks();
+});
+
+describe("TestConfigDialog", () => {
+  it("renders with current config values", () => {
+    useTestRunnerStore.setState({
+      config: {
+        [CTX]: {
+          framework: "vitest",
+          testCommand: "npx vitest --run",
+          testFileCommand: "npx vitest {file}",
+          workingDir: "packages/core",
+        },
+      },
+      saveConfig,
+      loadConfig,
+      detectFramework,
+    } as any);
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    const select = screen.getByDisplayValue("Vitest") as HTMLSelectElement;
+    expect(select.value).toBe("vitest");
+
+    const inputs = screen.getAllByRole("textbox");
+    expect((inputs[0] as HTMLInputElement).value).toBe("npx vitest --run");
+    expect((inputs[1] as HTMLInputElement).value).toBe("npx vitest {file}");
+    expect((inputs[2] as HTMLInputElement).value).toBe("packages/core");
+  });
+
+  it("renders with empty values when no config", () => {
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    const select = screen.getByDisplayValue("Not set") as HTMLSelectElement;
+    expect(select.value).toBe("");
+  });
+
+  it("Detect button calls detectFramework", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByText("Detect"));
+    expect(detectFramework).toHaveBeenCalledWith(CTX, REPO);
+  });
+
+  it("Save calls saveConfig then loadConfig then closes", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByText("Save"));
+
+    expect(saveConfig).toHaveBeenCalledWith(REPO, {
+      framework: null,
+      testCommand: null,
+      testFileCommand: null,
+      workingDir: null,
+    });
+    expect(loadConfig).toHaveBeenCalledWith(CTX, REPO);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("Cancel calls onClose", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clicking backdrop calls onClose", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    // The outermost overlay div
+    const overlay = container.firstElementChild as HTMLElement;
+    await user.click(overlay);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("framework dropdown has correct options", () => {
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    const options = screen.getAllByRole("option");
+    const values = options.map((o) => (o as HTMLOptionElement).value);
+    expect(values).toEqual([
+      "",
+      "vitest",
+      "jest",
+      "pytest",
+      "cargotest",
+      "gotest",
+      "custom",
+    ]);
+  });
+
+  it("constructs config correctly with empty strings as null", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByText("Save"));
+
+    expect(saveConfig).toHaveBeenCalledWith(REPO, {
+      framework: null,
+      testCommand: null,
+      testFileCommand: null,
+      workingDir: null,
+    });
+  });
+
+  it("syncs form when config changes", () => {
+    const { rerender } = render(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    // Simulate config update from store
+    useTestRunnerStore.setState({
+      config: {
+        [CTX]: {
+          framework: "jest",
+          testCommand: "npx jest",
+          testFileCommand: null,
+          workingDir: null,
+        },
+      },
+      saveConfig,
+      loadConfig,
+      detectFramework,
+    } as any);
+
+    rerender(
+      <TestConfigDialog contextId={CTX} repoId={REPO} onClose={onClose} />,
+    );
+
+    const select = screen.getByDisplayValue("Jest") as HTMLSelectElement;
+    expect(select.value).toBe("jest");
+  });
+});

--- a/src/components/test-runner/TestRunnerPanel.test.tsx
+++ b/src/components/test-runner/TestRunnerPanel.test.tsx
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TestSuite, TestResult, TestRunSummary, TestRunnerConfig } from "../../lib/tauri";
+
+// We mock the store at module level to avoid infinite re-render from `new Set()` fallback in selectors
+const subscribe = vi.fn().mockResolvedValue(undefined);
+const unsubscribe = vi.fn();
+const loadConfig = vi.fn().mockResolvedValue(undefined);
+const runTests = vi.fn().mockResolvedValue(undefined);
+const stopTests = vi.fn().mockResolvedValue(undefined);
+const clearResults = vi.fn();
+const setFilter = vi.fn();
+const toggleOutput = vi.fn();
+const toggleSuite = vi.fn();
+const selectTest = vi.fn();
+
+let storeValues: Record<string, any> = {};
+
+function getFullState() {
+  return {
+    suites: {},
+    summary: {},
+    output: {},
+    running: {},
+    error: {},
+    config: {},
+    filter: {},
+    expandedSuites: {},
+    selectedTest: {},
+    showOutput: {},
+    subscriptions: {},
+    subscribe,
+    unsubscribe,
+    loadConfig,
+    runTests,
+    stopTests,
+    clearResults,
+    setFilter,
+    toggleOutput,
+    toggleSuite,
+    selectTest,
+    ...storeValues,
+  };
+}
+
+vi.mock("../../stores/testRunnerStore", () => {
+  const hook = (selector: (s: any) => any) => {
+    const fullState = getFullState();
+    if (typeof selector === "function") return selector(fullState);
+    return fullState;
+  };
+  hook.getState = () => getFullState();
+  return { useTestRunnerStore: hook };
+});
+
+vi.mock("../../stores/workspaceStore", () => ({
+  useWorkspaceStore: (selector: (s: any) => any) => {
+    const state = {
+      workspaces: [{ id: "ctx-1", repoId: "repo-1", name: "Test WS" }],
+    };
+    if (typeof selector === "function") return selector(state);
+    return state;
+  },
+}));
+
+vi.mock("../../lib/tauri", () => ({
+  runTests: vi.fn(),
+  stopTests: vi.fn(),
+  getTestRunnerConfig: vi.fn(),
+  detectTestFramework: vi.fn(),
+  saveTestRunnerConfig: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("./TestConfigDialog", () => ({
+  TestConfigDialog: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="test-config-dialog">
+      <button onClick={onClose}>CloseConfig</button>
+    </div>
+  ),
+}));
+
+// Must import after vi.mock
+import { TestRunnerPanel } from "./TestRunnerPanel";
+
+const CTX = "ctx-1";
+
+function makeResult(overrides: Partial<TestResult> = {}): TestResult {
+  return {
+    name: "should work",
+    suite: "math",
+    status: "passed",
+    durationMs: 10,
+    failureMessage: null,
+    ...overrides,
+  };
+}
+
+function makeSuite(overrides: Partial<TestSuite> = {}): TestSuite {
+  return {
+    name: "math",
+    tests: [makeResult()],
+    status: "passed",
+    durationMs: 50,
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<TestRunSummary> = {}): TestRunSummary {
+  return {
+    total: 5,
+    passed: 3,
+    failed: 1,
+    skipped: 1,
+    durationMs: 500,
+    suites: [makeSuite()],
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<TestRunnerConfig> = {}): TestRunnerConfig {
+  return {
+    framework: "vitest",
+    testCommand: "npx vitest --run",
+    testFileCommand: null,
+    workingDir: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  storeValues = {};
+  vi.clearAllMocks();
+});
+
+describe("TestRunnerPanel", () => {
+  it("subscribes to events and loads config on mount", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(subscribe).toHaveBeenCalledWith(CTX);
+    expect(loadConfig).toHaveBeenCalledWith(CTX, "repo-1");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = render(
+      <TestRunnerPanel contextId={CTX} contextType="workspace" />,
+    );
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledWith(CTX);
+  });
+
+  it("shows Not configured when no config", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Not configured")).toBeTruthy();
+  });
+
+  it("shows framework label when config exists", () => {
+    storeValues = { config: { [CTX]: makeConfig({ framework: "vitest" }) } };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Vitest")).toBeTruthy();
+  });
+
+  it("shows No test results yet when config exists but no suites", () => {
+    storeValues = { config: { [CTX]: makeConfig() } };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("No test results yet")).toBeTruthy();
+  });
+
+  it("shows No test framework detected when no config", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("No test framework detected")).toBeTruthy();
+  });
+
+  it("shows Configure Test Runner button when no config", async () => {
+    const user = userEvent.setup();
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    const btn = screen.getByText("Configure Test Runner");
+    expect(btn).toBeTruthy();
+    await user.click(btn);
+    expect(screen.getByTestId("test-config-dialog")).toBeTruthy();
+  });
+
+  it("Run All button calls runTests", async () => {
+    const user = userEvent.setup();
+    storeValues = { config: { [CTX]: makeConfig() } };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    await user.click(screen.getByText("Run All"));
+    expect(runTests).toHaveBeenCalledWith(CTX, "workspace");
+  });
+
+  it("Run All button is disabled when no config", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    const runBtn = screen.getByText("Run All").closest("button")!;
+    expect(runBtn.disabled).toBe(true);
+  });
+
+  it("shows Stop button when running", () => {
+    storeValues = {
+      running: { [CTX]: true },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Stop")).toBeTruthy();
+    expect(screen.queryByText("Run All")).toBeNull();
+  });
+
+  it("Stop button calls stopTests", async () => {
+    const user = userEvent.setup();
+    storeValues = {
+      running: { [CTX]: true },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    await user.click(screen.getByText("Stop"));
+    expect(stopTests).toHaveBeenCalledWith(CTX);
+  });
+
+  it("Clear button calls clearResults", async () => {
+    const user = userEvent.setup();
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    await user.click(screen.getByTitle("Clear results"));
+    expect(clearResults).toHaveBeenCalledWith(CTX);
+  });
+
+  it("Settings button opens config dialog", async () => {
+    const user = userEvent.setup();
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    await user.click(screen.getByTitle("Configure test runner"));
+    expect(screen.getByTestId("test-config-dialog")).toBeTruthy();
+  });
+
+  it("renders suite rows", () => {
+    storeValues = {
+      suites: { [CTX]: [makeSuite({ name: "math" }), makeSuite({ name: "utils" })] },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    expect(screen.getByText("math")).toBeTruthy();
+    expect(screen.getByText("utils")).toBeTruthy();
+  });
+
+  it("shows Running... text when running", () => {
+    storeValues = {
+      running: { [CTX]: true },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Running...")).toBeTruthy();
+  });
+
+  it("shows summary badges when summary exists", () => {
+    storeValues = {
+      summary: { [CTX]: makeSummary({ total: 5, passed: 3, failed: 1, skipped: 1 }) },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+
+    expect(screen.getByText("5 tests")).toBeTruthy();
+    expect(screen.getByText("3 passed")).toBeTruthy();
+    expect(screen.getByText("1 failed")).toBeTruthy();
+    expect(screen.getByText("1 skipped")).toBeTruthy();
+  });
+
+  it("shows error banner when error is set", () => {
+    storeValues = {
+      error: { [CTX]: "Failed to start tests" },
+      config: { [CTX]: makeConfig() },
+    };
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Failed to start tests")).toBeTruthy();
+  });
+
+  it("filter buttons render correctly", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("All")).toBeTruthy();
+    expect(screen.getByText("Failed")).toBeTruthy();
+    expect(screen.getByText("Passed")).toBeTruthy();
+    expect(screen.getByText("Skipped")).toBeTruthy();
+  });
+
+  it("Output toggle button renders", () => {
+    render(<TestRunnerPanel contextId={CTX} contextType="workspace" />);
+    expect(screen.getByText("Output")).toBeTruthy();
+  });
+});

--- a/src/hooks/useAutoUpdate.test.ts
+++ b/src/hooks/useAutoUpdate.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../lib/tauri", () => ({
+  checkForUpdate: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: vi.fn(),
+}));
+
+import { useAutoUpdate } from "./useAutoUpdate";
+import { checkForUpdate } from "../lib/tauri";
+import { useToastStore } from "../stores/toastStore";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useToastStore.setState({ toasts: [] });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAutoUpdate", () => {
+  it("shows update toast when update available", async () => {
+    const mockDownloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      version: "2.0.0",
+      downloadAndInstall: mockDownloadAndInstall,
+    } as any);
+
+    renderHook(() => useAutoUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      // Flush microtasks
+      await Promise.resolve();
+    });
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts.length).toBeGreaterThanOrEqual(1);
+    expect(toasts[0].message).toContain("v2.0.0");
+    expect(toasts[0].type).toBe("info");
+  });
+
+  it("does not show toast when no update available", async () => {
+    vi.mocked(checkForUpdate).mockResolvedValue(null as any);
+
+    renderHook(() => useAutoUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("silently catches checkForUpdate errors", async () => {
+    vi.mocked(checkForUpdate).mockRejectedValue(new Error("network error"));
+
+    renderHook(() => useAutoUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("clears timeout on unmount", async () => {
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      version: "2.0.0",
+      downloadAndInstall: vi.fn(),
+    } as any);
+
+    const { unmount } = renderHook(() => useAutoUpdate());
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("action callback calls downloadAndInstall then relaunch", async () => {
+    const mockDownloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      version: "2.0.0",
+      downloadAndInstall: mockDownloadAndInstall,
+    } as any);
+    vi.mocked(relaunch).mockResolvedValue(undefined);
+
+    renderHook(() => useAutoUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    const toast = useToastStore.getState().toasts[0];
+    expect(toast.action).toBeDefined();
+
+    await act(async () => {
+      await toast.action!.onClick();
+    });
+
+    expect(mockDownloadAndInstall).toHaveBeenCalled();
+    expect(relaunch).toHaveBeenCalled();
+  });
+
+  it("action callback shows error toast on install failure", async () => {
+    const mockDownloadAndInstall = vi.fn().mockRejectedValue(new Error("install failed"));
+    vi.mocked(checkForUpdate).mockResolvedValue({
+      version: "2.0.0",
+      downloadAndInstall: mockDownloadAndInstall,
+    } as any);
+
+    renderHook(() => useAutoUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    const toast = useToastStore.getState().toasts[0];
+    await act(async () => {
+      await toast.action!.onClick();
+    });
+
+    const toasts = useToastStore.getState().toasts;
+    const errorToast = toasts.find((t) => t.type === "error");
+    expect(errorToast).toBeDefined();
+    expect(errorToast!.message).toContain("install failed");
+  });
+});

--- a/src/stores/bookmarkStore.test.ts
+++ b/src/stores/bookmarkStore.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../lib/tauri", () => ({
+  listBookmarks: vi.fn(),
+  createBookmark: vi.fn(),
+  updateBookmark: vi.fn(),
+  deleteBookmark: vi.fn(),
+  toggleBookmark: vi.fn(),
+}));
+
+import { useBookmarkStore } from "./bookmarkStore";
+import { useToastStore } from "./toastStore";
+import {
+  listBookmarks,
+  createBookmark,
+  updateBookmark,
+  deleteBookmark,
+  toggleBookmark,
+} from "../lib/tauri";
+import type { FileBookmark } from "../lib/tauri";
+
+function makeBookmark(overrides: Partial<FileBookmark> = {}): FileBookmark {
+  return {
+    id: "bm-1",
+    repoId: "repo-1",
+    filePath: "src/index.ts",
+    lineNumber: 10,
+    note: null,
+    color: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBookmarkStore.setState({
+    bookmarks: {},
+    loading: {},
+    error: {},
+    editingBookmark: null,
+  });
+  useToastStore.setState({
+    toasts: [],
+  });
+  vi.clearAllMocks();
+});
+
+describe("bookmarkStore - loadBookmarks", () => {
+  it("loads bookmarks and sets loading state", async () => {
+    const bookmarks = [makeBookmark()];
+    vi.mocked(listBookmarks).mockResolvedValue(bookmarks);
+
+    await useBookmarkStore.getState().loadBookmarks("repo-1");
+
+    expect(useBookmarkStore.getState().bookmarks["repo-1"]).toEqual(bookmarks);
+    expect(useBookmarkStore.getState().loading["repo-1"]).toBe(false);
+    expect(listBookmarks).toHaveBeenCalledWith("repo-1");
+  });
+
+  it("sets error on failure", async () => {
+    vi.mocked(listBookmarks).mockRejectedValue(new Error("db fail"));
+
+    await useBookmarkStore.getState().loadBookmarks("repo-1");
+
+    expect(useBookmarkStore.getState().error["repo-1"]).toBe("Error: db fail");
+    expect(useBookmarkStore.getState().loading["repo-1"]).toBe(false);
+  });
+
+  it("deduplicates concurrent calls via inflight guard", async () => {
+    let resolveFirst: (v: FileBookmark[]) => void;
+    const firstCall = new Promise<FileBookmark[]>((r) => {
+      resolveFirst = r;
+    });
+    vi.mocked(listBookmarks).mockImplementation(() => firstCall);
+
+    const p1 = useBookmarkStore.getState().loadBookmarks("repo-1");
+    const p2 = useBookmarkStore.getState().loadBookmarks("repo-1");
+
+    resolveFirst!([makeBookmark()]);
+    await Promise.all([p1, p2]);
+
+    expect(listBookmarks).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows new call after first completes", async () => {
+    vi.mocked(listBookmarks).mockResolvedValue([]);
+
+    await useBookmarkStore.getState().loadBookmarks("repo-1");
+    await useBookmarkStore.getState().loadBookmarks("repo-1");
+
+    expect(listBookmarks).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("bookmarkStore - toggleBookmark", () => {
+  it("adds bookmark and shows toast when result is truthy", async () => {
+    const bm = makeBookmark();
+    vi.mocked(toggleBookmark).mockResolvedValue(bm as any);
+    vi.mocked(listBookmarks).mockResolvedValue([bm]);
+
+    await useBookmarkStore.getState().toggleBookmark("repo-1", "src/index.ts", 10);
+
+    expect(listBookmarks).toHaveBeenCalledWith("repo-1");
+    expect(useBookmarkStore.getState().bookmarks["repo-1"]).toEqual([bm]);
+    expect(useToastStore.getState().toasts[0].message).toBe("Bookmark added");
+  });
+
+  it("removes bookmark and shows toast when result is null", async () => {
+    vi.mocked(toggleBookmark).mockResolvedValue(null as any);
+    vi.mocked(listBookmarks).mockResolvedValue([]);
+
+    await useBookmarkStore.getState().toggleBookmark("repo-1", "src/index.ts", 10);
+
+    expect(useToastStore.getState().toasts[0].message).toBe("Bookmark removed");
+  });
+
+  it("sets error on failure", async () => {
+    vi.mocked(toggleBookmark).mockRejectedValue(new Error("fail"));
+
+    await useBookmarkStore.getState().toggleBookmark("repo-1", "src/index.ts", 10);
+
+    expect(useBookmarkStore.getState().error["repo-1"]).toBe("Error: fail");
+  });
+});
+
+describe("bookmarkStore - addBookmark", () => {
+  it("creates bookmark, reloads list, shows toast, and returns bookmark", async () => {
+    const bm = makeBookmark({ id: "bm-new" });
+    vi.mocked(createBookmark).mockResolvedValue(bm);
+    vi.mocked(listBookmarks).mockResolvedValue([bm]);
+
+    const result = await useBookmarkStore.getState().addBookmark({
+      repoId: "repo-1",
+      filePath: "src/index.ts",
+      lineNumber: 10,
+    });
+
+    expect(result).toEqual(bm);
+    expect(useBookmarkStore.getState().bookmarks["repo-1"]).toEqual([bm]);
+    expect(useToastStore.getState().toasts[0].message).toBe("Bookmark added");
+  });
+
+  it("sets error and re-throws on failure", async () => {
+    vi.mocked(createBookmark).mockRejectedValue(new Error("db error"));
+
+    await expect(
+      useBookmarkStore.getState().addBookmark({
+        repoId: "repo-1",
+        filePath: "src/index.ts",
+        lineNumber: 10,
+      }),
+    ).rejects.toThrow("db error");
+
+    expect(useBookmarkStore.getState().error["repo-1"]).toBe("Error: db error");
+  });
+});
+
+describe("bookmarkStore - editBookmark", () => {
+  it("updates bookmark and reloads list", async () => {
+    const updated = makeBookmark({ note: "edited" });
+    vi.mocked(updateBookmark).mockResolvedValue(updated);
+    vi.mocked(listBookmarks).mockResolvedValue([updated]);
+
+    await useBookmarkStore.getState().editBookmark("repo-1", "bm-1", {
+      note: "edited",
+    });
+
+    expect(updateBookmark).toHaveBeenCalledWith("bm-1", { note: "edited" });
+    expect(useBookmarkStore.getState().bookmarks["repo-1"]).toEqual([updated]);
+  });
+
+  it("sets error and re-throws on failure", async () => {
+    vi.mocked(updateBookmark).mockRejectedValue(new Error("not found"));
+
+    await expect(
+      useBookmarkStore.getState().editBookmark("repo-1", "bm-1", { note: "x" }),
+    ).rejects.toThrow("not found");
+
+    expect(useBookmarkStore.getState().error["repo-1"]).toBe("Error: not found");
+  });
+});
+
+describe("bookmarkStore - removeBookmark", () => {
+  it("deletes bookmark, removes from local state, shows toast", async () => {
+    const bm1 = makeBookmark({ id: "bm-1" });
+    const bm2 = makeBookmark({ id: "bm-2", lineNumber: 20 });
+    useBookmarkStore.setState({ bookmarks: { "repo-1": [bm1, bm2] } });
+    vi.mocked(deleteBookmark).mockResolvedValue(undefined);
+
+    await useBookmarkStore.getState().removeBookmark("repo-1", "bm-1");
+
+    expect(deleteBookmark).toHaveBeenCalledWith("bm-1");
+    expect(useBookmarkStore.getState().bookmarks["repo-1"]).toEqual([bm2]);
+    expect(useToastStore.getState().toasts[0].message).toBe("Bookmark removed");
+  });
+
+  it("sets error on failure", async () => {
+    vi.mocked(deleteBookmark).mockRejectedValue(new Error("db error"));
+
+    await useBookmarkStore.getState().removeBookmark("repo-1", "bm-1");
+
+    expect(useBookmarkStore.getState().error["repo-1"]).toBe("Error: db error");
+  });
+});
+
+describe("bookmarkStore - sync helpers", () => {
+  it("setEditingBookmark sets and clears editing state", () => {
+    const editing = {
+      repoId: "repo-1",
+      filePath: "src/index.ts",
+      lineNumber: 10,
+    };
+    useBookmarkStore.getState().setEditingBookmark(editing);
+    expect(useBookmarkStore.getState().editingBookmark).toEqual(editing);
+
+    useBookmarkStore.getState().setEditingBookmark(null);
+    expect(useBookmarkStore.getState().editingBookmark).toBeNull();
+  });
+
+  it("getBookmarksForFile filters by filePath", () => {
+    const bm1 = makeBookmark({ filePath: "src/a.ts" });
+    const bm2 = makeBookmark({ id: "bm-2", filePath: "src/b.ts" });
+    useBookmarkStore.setState({ bookmarks: { "repo-1": [bm1, bm2] } });
+
+    const result = useBookmarkStore.getState().getBookmarksForFile("repo-1", "src/a.ts");
+    expect(result).toEqual([bm1]);
+  });
+
+  it("getBookmarksForFile returns empty array for unknown repo", () => {
+    const result = useBookmarkStore.getState().getBookmarksForFile("unknown", "src/a.ts");
+    expect(result).toEqual([]);
+  });
+});

--- a/src/stores/testRunnerStore.test.ts
+++ b/src/stores/testRunnerStore.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../lib/tauri", () => ({
+  runTests: vi.fn(),
+  stopTests: vi.fn(),
+  getTestRunnerConfig: vi.fn(),
+  detectTestFramework: vi.fn(),
+  saveTestRunnerConfig: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+import { useTestRunnerStore } from "./testRunnerStore";
+import {
+  runTests as runTestsCmd,
+  stopTests as stopTestsCmd,
+  getTestRunnerConfig,
+  detectTestFramework,
+  saveTestRunnerConfig,
+} from "../lib/tauri";
+import type {
+  TestSuite,
+  TestResult,
+  TestRunSummary,
+  TestRunnerConfig,
+} from "../lib/tauri";
+import { listen } from "@tauri-apps/api/event";
+
+const CTX = "ctx-1";
+
+function makeResult(overrides: Partial<TestResult> = {}): TestResult {
+  return {
+    name: "should work",
+    suite: "math",
+    status: "passed",
+    durationMs: 10,
+    failureMessage: null,
+    ...overrides,
+  };
+}
+
+function makeSuite(overrides: Partial<TestSuite> = {}): TestSuite {
+  return {
+    name: "math",
+    tests: [makeResult()],
+    status: "passed",
+    durationMs: 50,
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<TestRunSummary> = {}): TestRunSummary {
+  return {
+    total: 1,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    durationMs: 100,
+    suites: [makeSuite()],
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<TestRunnerConfig> = {}): TestRunnerConfig {
+  return {
+    framework: "vitest",
+    testCommand: "npx vitest --run",
+    testFileCommand: null,
+    workingDir: null,
+    ...overrides,
+  };
+}
+
+let capturedCallback: ((event: { payload: any }) => void) | null = null;
+const mockUnlisten = vi.fn();
+
+beforeEach(() => {
+  useTestRunnerStore.setState({
+    suites: {},
+    summary: {},
+    output: {},
+    running: {},
+    error: {},
+    config: {},
+    filter: {},
+    expandedSuites: {},
+    selectedTest: {},
+    showOutput: {},
+    subscriptions: {},
+  });
+  capturedCallback = null;
+  vi.clearAllMocks();
+  vi.mocked(listen).mockImplementation(async (_event, cb) => {
+    capturedCallback = cb as any;
+    return mockUnlisten;
+  });
+});
+
+describe("testRunnerStore - subscribe/unsubscribe", () => {
+  it("subscribe registers listener and stores unlisten fn", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+
+    expect(listen).toHaveBeenCalledWith(`test-runner:${CTX}`, expect.any(Function));
+    expect(useTestRunnerStore.getState().subscriptions[CTX]).toHaveLength(1);
+  });
+
+  it("subscribe is idempotent", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    await useTestRunnerStore.getState().subscribe(CTX);
+
+    expect(listen).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe calls unlisten and removes subscription", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    useTestRunnerStore.getState().unsubscribe(CTX);
+
+    expect(mockUnlisten).toHaveBeenCalled();
+    expect(useTestRunnerStore.getState().subscriptions[CTX]).toBeUndefined();
+  });
+
+  it("unsubscribe is safe when no subscription exists", () => {
+    useTestRunnerStore.getState().unsubscribe(CTX);
+    expect(mockUnlisten).not.toHaveBeenCalled();
+  });
+});
+
+describe("testRunnerStore - event handling", () => {
+  it("suiteUpdate event adds new suite", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    const suite = makeSuite({ name: "utils" });
+
+    capturedCallback!({ payload: { type: "suiteUpdate", suite } });
+
+    expect(useTestRunnerStore.getState().suites[CTX]).toEqual([suite]);
+  });
+
+  it("suiteUpdate event replaces existing suite by name", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    const original = makeSuite({ name: "math", status: "running" });
+    capturedCallback!({ payload: { type: "suiteUpdate", suite: original } });
+
+    const updated = makeSuite({ name: "math", status: "passed" });
+    capturedCallback!({ payload: { type: "suiteUpdate", suite: updated } });
+
+    expect(useTestRunnerStore.getState().suites[CTX]).toEqual([updated]);
+  });
+
+  it("runComplete event sets summary, suites, running=false", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    useTestRunnerStore.setState({ running: { [CTX]: true } });
+    const summary = makeSummary();
+
+    capturedCallback!({ payload: { type: "runComplete", summary } });
+
+    expect(useTestRunnerStore.getState().summary[CTX]).toEqual(summary);
+    expect(useTestRunnerStore.getState().suites[CTX]).toEqual(summary.suites);
+    expect(useTestRunnerStore.getState().running[CTX]).toBe(false);
+  });
+
+  it("outputLine event appends stdout line", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+
+    capturedCallback!({ payload: { type: "outputLine", line: "PASS math.test.ts", stream: "stdout" } });
+
+    expect(useTestRunnerStore.getState().output[CTX]).toEqual(["PASS math.test.ts"]);
+  });
+
+  it("outputLine event prepends [stderr] prefix", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+
+    capturedCallback!({ payload: { type: "outputLine", line: "warning", stream: "stderr" } });
+
+    expect(useTestRunnerStore.getState().output[CTX]).toEqual(["[stderr] warning"]);
+  });
+
+  it("error event sets error and running=false", async () => {
+    await useTestRunnerStore.getState().subscribe(CTX);
+    useTestRunnerStore.setState({ running: { [CTX]: true } });
+
+    capturedCallback!({ payload: { type: "error", message: "Process exited with code 1" } });
+
+    expect(useTestRunnerStore.getState().error[CTX]).toBe("Process exited with code 1");
+    expect(useTestRunnerStore.getState().running[CTX]).toBe(false);
+  });
+});
+
+describe("testRunnerStore - loadConfig / detectFramework / saveConfig", () => {
+  it("loadConfig fetches and stores config", async () => {
+    const config = makeConfig();
+    vi.mocked(getTestRunnerConfig).mockResolvedValue(config);
+
+    await useTestRunnerStore.getState().loadConfig(CTX, "repo-1");
+
+    expect(getTestRunnerConfig).toHaveBeenCalledWith("repo-1");
+    expect(useTestRunnerStore.getState().config[CTX]).toEqual(config);
+  });
+
+  it("loadConfig logs error on failure", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getTestRunnerConfig).mockRejectedValue(new Error("fail"));
+
+    await useTestRunnerStore.getState().loadConfig(CTX, "repo-1");
+
+    expect(spy).toHaveBeenCalledWith(
+      "[testRunnerStore] Failed to load config:",
+      expect.any(Error),
+    );
+    spy.mockRestore();
+  });
+
+  it("detectFramework detects and stores config", async () => {
+    const config = makeConfig({ framework: "jest" });
+    vi.mocked(detectTestFramework).mockResolvedValue(config);
+
+    await useTestRunnerStore.getState().detectFramework(CTX, "repo-1");
+
+    expect(detectTestFramework).toHaveBeenCalledWith("repo-1");
+    expect(useTestRunnerStore.getState().config[CTX]).toEqual(config);
+  });
+
+  it("detectFramework logs error on failure", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(detectTestFramework).mockRejectedValue(new Error("fail"));
+
+    await useTestRunnerStore.getState().detectFramework(CTX, "repo-1");
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("saveConfig calls saveTestRunnerConfig", async () => {
+    const config = makeConfig();
+    vi.mocked(saveTestRunnerConfig).mockResolvedValue(undefined);
+
+    await useTestRunnerStore.getState().saveConfig("repo-1", config);
+
+    expect(saveTestRunnerConfig).toHaveBeenCalledWith("repo-1", config);
+  });
+
+  it("saveConfig logs error on failure", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(saveTestRunnerConfig).mockRejectedValue(new Error("fail"));
+
+    await useTestRunnerStore.getState().saveConfig("repo-1", makeConfig());
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("testRunnerStore - runTests", () => {
+  it("sets running=true, clears error/output/summary, resets suite statuses", async () => {
+    const suite = makeSuite({
+      status: "passed",
+      tests: [makeResult({ status: "passed" })],
+    });
+    useTestRunnerStore.setState({ suites: { [CTX]: [suite] } });
+    vi.mocked(runTestsCmd).mockResolvedValue(undefined);
+
+    await useTestRunnerStore.getState().runTests(CTX, "workspace");
+
+    const state = useTestRunnerStore.getState();
+    expect(state.running[CTX]).toBe(true);
+    expect(state.error[CTX]).toBeNull();
+    expect(state.output[CTX]).toEqual([]);
+    expect(state.summary[CTX]).toBeNull();
+    expect(state.suites[CTX][0].status).toBe("running");
+    expect(state.suites[CTX][0].tests[0].status).toBe("running");
+  });
+
+  it("calls runTestsCmd with correct args", async () => {
+    vi.mocked(runTestsCmd).mockResolvedValue(undefined);
+
+    await useTestRunnerStore.getState().runTests(CTX, "workspace", "file.test.ts");
+
+    expect(runTestsCmd).toHaveBeenCalledWith(CTX, "workspace", "file.test.ts");
+  });
+
+  it("sets error and running=false on failure", async () => {
+    vi.mocked(runTestsCmd).mockRejectedValue(new Error("spawn failed"));
+
+    await useTestRunnerStore.getState().runTests(CTX, "workspace");
+
+    expect(useTestRunnerStore.getState().running[CTX]).toBe(false);
+    expect(useTestRunnerStore.getState().error[CTX]).toContain("spawn failed");
+  });
+});
+
+describe("testRunnerStore - stopTests", () => {
+  it("calls stopTestsCmd and sets running=false", async () => {
+    useTestRunnerStore.setState({ running: { [CTX]: true } });
+    vi.mocked(stopTestsCmd).mockResolvedValue(undefined);
+
+    await useTestRunnerStore.getState().stopTests(CTX);
+
+    expect(stopTestsCmd).toHaveBeenCalledWith(CTX);
+    expect(useTestRunnerStore.getState().running[CTX]).toBe(false);
+  });
+
+  it("logs error on failure", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(stopTestsCmd).mockRejectedValue(new Error("fail"));
+
+    await useTestRunnerStore.getState().stopTests(CTX);
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("testRunnerStore - UI actions", () => {
+  it("setFilter updates filter for context", () => {
+    useTestRunnerStore.getState().setFilter(CTX, "failed");
+    expect(useTestRunnerStore.getState().filter[CTX]).toBe("failed");
+  });
+
+  it("toggleSuite adds suite to expanded set", () => {
+    useTestRunnerStore.getState().toggleSuite(CTX, "math");
+    expect(useTestRunnerStore.getState().expandedSuites[CTX].has("math")).toBe(true);
+  });
+
+  it("toggleSuite removes suite from expanded set", () => {
+    useTestRunnerStore.getState().toggleSuite(CTX, "math");
+    useTestRunnerStore.getState().toggleSuite(CTX, "math");
+    expect(useTestRunnerStore.getState().expandedSuites[CTX].has("math")).toBe(false);
+  });
+
+  it("selectTest sets selected test", () => {
+    useTestRunnerStore.getState().selectTest(CTX, "math", "adds numbers");
+    expect(useTestRunnerStore.getState().selectedTest[CTX]).toEqual({
+      suite: "math",
+      name: "adds numbers",
+    });
+  });
+
+  it("toggleOutput flips showOutput", () => {
+    useTestRunnerStore.getState().toggleOutput(CTX);
+    expect(useTestRunnerStore.getState().showOutput[CTX]).toBe(true);
+    useTestRunnerStore.getState().toggleOutput(CTX);
+    expect(useTestRunnerStore.getState().showOutput[CTX]).toBe(false);
+  });
+
+  it("clearResults resets suites, summary, output, error, selectedTest", () => {
+    useTestRunnerStore.setState({
+      suites: { [CTX]: [makeSuite()] },
+      summary: { [CTX]: makeSummary() },
+      output: { [CTX]: ["line1"] },
+      error: { [CTX]: "some error" },
+      selectedTest: { [CTX]: { suite: "math", name: "test" } },
+    });
+
+    useTestRunnerStore.getState().clearResults(CTX);
+
+    const state = useTestRunnerStore.getState();
+    expect(state.suites[CTX]).toEqual([]);
+    expect(state.summary[CTX]).toBeNull();
+    expect(state.output[CTX]).toEqual([]);
+    expect(state.error[CTX]).toBeNull();
+    expect(state.selectedTest[CTX]).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds test files for ChatSearch, BookmarkNoteDialog, NotificationBell, NotificationPanel, BookmarksPanel, TestConfigDialog, and TestRunnerPanel components
- Adds tests for useAutoUpdate hook and bookmarkStore, testRunnerStore stores
- Fixes TypeScript type error in bookmarkStore test (mockResolvedValue with correct FileBookmark type)

## Test plan
- [ ] Run `npm test` to verify all new test files pass
- [ ] Check TypeScript compilation with `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)