### PR TITLE
Make right sidebar tabs scrollable and keep sync button visible

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+@utility scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Default theme: blend (black base + Figma panels + blue accent).
    Themes are applied dynamically via src/lib/themes.ts — these are fallback defaults. */
 :root {

--- a/src/components/layout/RightSidebar.tsx
+++ b/src/components/layout/RightSidebar.tsx
@@ -206,31 +206,35 @@ export function RightSidebar({ context }: Props) {
                 paddingTop: isMac ? 42 : 10,
               }}
             >
-              {tabs.map((tab) => {
-                const isActive = activeTab === tab.key;
-                const label =
-                  tab.key === "changes" && changeCount > 0
-                    ? `${tab.label} ${changeCount}`
-                    : tab.label;
-                return (
-                  <button
-                    key={tab.key}
-                    onClick={() => setTab(tab.key)}
-                    className="px-5 py-2.5 transition-colors"
-                    style={{
-                      color: isActive
-                        ? "var(--accent)"
-                        : "var(--text-muted)",
-                      borderBottom: isActive
-                        ? "2px solid var(--accent)"
-                        : "2px solid transparent",
-                    }}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-              <SyncButton contextId={context.id} />
+              <div className="flex min-w-0 flex-1 items-end overflow-x-auto scrollbar-hide">
+                {tabs.map((tab) => {
+                  const isActive = activeTab === tab.key;
+                  const label =
+                    tab.key === "changes" && changeCount > 0
+                      ? `${tab.label} ${changeCount}`
+                      : tab.label;
+                  return (
+                    <button
+                      key={tab.key}
+                      onClick={() => setTab(tab.key)}
+                      className="shrink-0 whitespace-nowrap px-5 py-2.5 transition-colors"
+                      style={{
+                        color: isActive
+                          ? "var(--accent)"
+                          : "var(--text-muted)",
+                        borderBottom: isActive
+                          ? "2px solid var(--accent)"
+                          : "2px solid transparent",
+                      }}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="shrink-0 pb-2.5">
+                <SyncButton contextId={context.id} />
+              </div>
             </div>
 
             {/* Tab content — FileTreePanel stays mounted to preserve scroll/expand state */}


### PR DESCRIPTION
Improves tab bar UX when the right sidebar is narrow:

- Tabs now scroll horizontally instead of squishing
- Sync button is pinned to the right and always visible
- Scrollbar is hidden for a cleaner look
- Sync button aligns vertically with tab labels