### PR TITLE
Update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Backend → frontend streaming uses Tauri events: `listen("agent-stream:${worksp
 
 ### Frontend (src/)
 
-**Stores** (`src/stores/`) — 46 Zustand stores. Use individual selectors to prevent re-renders:
+**Stores** (`src/stores/`) — 27 Zustand stores. Use individual selectors to prevent re-renders:
 ```typescript
 // Correct
 const activeId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -67,7 +67,7 @@ const { activeWorkspaceId } = useWorkspaceStore();
 
 **Structure:**
 - `commands/` — Tauri command handlers (thin layer, delegates to services)
-- `services/` — Business logic: `claude_process.rs`, `codex_process.rs`, `git.rs`, `gh.rs`, `diff.rs`, `copilot_lsp.rs`, etc.
+- `services/` — Business logic: `claude_process.rs`, `codex_process.rs`, `gh.rs`, `diff.rs`, `copilot_lsp.rs`, `branch.rs`, etc.
 - `models/` — Serde-serializable types shared with frontend
 - `state/app_state.rs` — Singleton `AppState` with `Mutex<HashMap<Uuid, T>>` for runtime state
 - `db/` — SQLite (rusqlite) with WAL mode, versioned migrations in `db/migrations/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,17 +59,27 @@ Run `npm run lint` before submitting a PR.
 ```
 src/                    # React frontend (TypeScript)
 ├── components/         # UI components
+│   ├── activity-log/   # Activity timeline
 │   ├── chat/           # Chat interface
-│   ├── layout/         # App layout (Sidebar, TopBar, etc.)
-│   ├── terminal/       # Terminal panels (xterm)
-│   ├── file-viewer/    # Monaco file viewer
 │   ├── diff/           # Diff viewer
+│   ├── file-viewer/    # Monaco file viewer
+│   ├── history/        # History view
+│   ├── icons/          # Icon components
+│   ├── landing/        # Landing page
+│   ├── layout/         # App layout (Sidebar, TopBar, etc.)
 │   ├── merge/          # Merge view and conflict resolution
+│   ├── notes/          # Notes/todos panel
+│   ├── notifications/  # Notification center
 │   ├── pr/             # PR management panel
-│   ├── sidebar/        # Right sidebar panels (files, changes, checks)
+│   ├── prompt-library/ # Saved prompts
 │   ├── settings/       # Settings panels
-│   ├── workspace/      # Workspace dialogs
-│   └── ...
+│   ├── sidebar/        # Right sidebar panels (files, changes, checks)
+│   ├── snippets/       # Snippet manager
+│   ├── team/           # Team features
+│   ├── terminal/       # Terminal panels (xterm)
+│   ├── test-runner/    # Test runner panel
+│   ├── usage/          # Usage/cost tracking
+│   └── workspace/      # Workspace dialogs
 ├── stores/             # Zustand state stores (one per domain)
 └── lib/                # Utilities and Tauri bindings
 

--- a/docs/core/scripts.mdx
+++ b/docs/core/scripts.mdx
@@ -65,5 +65,6 @@ Scripts have access to these environment variables automatically:
 | `FURY_WORKSPACE_PATH` | Absolute path to the worktree |
 | `FURY_ROOT_PATH` | Absolute path to the main repo |
 | `FURY_DEFAULT_BRANCH` | Repository's default branch |
+| `FURY_PORT` | Base port allocated to the workspace |
 
 You can also configure custom environment variables per-repository in Settings. See [environment variables](/tips/environment-variables).

--- a/docs/tips/environment-variables.mdx
+++ b/docs/tips/environment-variables.mdx
@@ -17,6 +17,7 @@ Fury automatically provides these environment variables to scripts:
 | `FURY_WORKSPACE_PATH` | Absolute path to the workspace worktree |
 | `FURY_ROOT_PATH` | Absolute path to the main repository |
 | `FURY_DEFAULT_BRANCH` | Repository's default branch (e.g., `main`) |
+| `FURY_PORT` | Base port allocated to the workspace (e.g., `10000`) |
 
 ## Provider variables
 

--- a/docs/tips/workspaces-and-branches.mdx
+++ b/docs/tips/workspaces-and-branches.mdx
@@ -21,12 +21,12 @@ By default, worktrees are created alongside your repository. You can configure a
 
 ## Port allocation
 
-Each workspace gets a port base number, incremented by 100 from previous workspaces. This prevents port conflicts when multiple dev servers are running simultaneously.
+Each workspace gets a block of 10 ports, starting at port 10000 and incrementing by 10. This prevents port conflicts when multiple dev servers are running simultaneously.
 
 For example:
-- Workspace 1: ports starting at 3000
-- Workspace 2: ports starting at 3100
-- Workspace 3: ports starting at 3200
+- Workspace 1: ports 10000–10009
+- Workspace 2: ports 10010–10019
+- Workspace 3: ports 10020–10029
 
 ## Branch naming
 

--- a/e2e/TEST-ROADMAP.md
+++ b/e2e/TEST-ROADMAP.md
@@ -1,6 +1,6 @@
 # E2E Test Roadmap
 
-Total: 78 tests across 16 suites. All passing.
+Total: 83 tests across 18 suites. All passing.
 
 ## Phase 1 — Core Flows (done)
 20 tests across 4 suites.
@@ -76,23 +76,21 @@ Total: 78 tests across 16 suites. All passing.
   - Updates tab shows version and check button
 
 ## Phase 8 — PR Panel (done)
-6 tests in 1 suite.
+5 tests in 1 suite.
 
-- [x] `pr-panel.spec.ts` (6 tests)
-  - Create PR form shows with title input defaulting to branch name
-  - Title defaults to workspace branch name
-  - Create PR button submits and shows PR status
-  - PR status view shows number and title
-  - CI checks display with success/failure/pending indicators
+- [x] `pr-panel.spec.ts` (5 tests)
+  - Shows Create PR button when no PR exists
+  - Create PR button triggers agent message
+  - PR number and title shown in status view
+  - CI checks display with status indicators
   - Push button and Fix with Claude button visible
 
 ## Phase 9 — Workspace Dialogs (done)
-5 tests in 1 suite.
+4 tests in 1 suite.
 
-- [x] `workspace-dialogs.spec.ts` (5 tests)
+- [x] `workspace-dialogs.spec.ts` (4 tests)
   - New workspace dialog opens from sidebar button
-  - Task description textarea and worktree name input visible
-  - Generate button creates name from task description
+  - Worktree name input visible
   - Branch dropdown loads branches from mock
   - Cancel closes dialog
 
@@ -131,3 +129,15 @@ NotesPanel component is defined but not rendered in the app yet.
   - Agent error status shows error indicator
   - Empty workspace shows help text with no messages
   - Streaming with pending text shows Running indicator
+
+## Phase 15 — Prompt Library (done)
+7 tests in 1 suite.
+
+- [x] `prompt-library.spec.ts` (7 tests)
+  - Opens prompt library from plus menu
+  - Creates a new prompt with name, content, description, and category
+  - Inserts a simple prompt into the composer
+  - Searches and filters prompts by text
+  - Shows category filter pills and filters by category
+  - Closes prompt library with Close button
+  - Slash command /prompt: autocomplete shows saved prompts


### PR DESCRIPTION
## Summary
- Fixed store count: 46 → 27 (actual Zustand stores in src/stores/)
- Replaced nonexistent `git.rs` service reference with `branch.rs` in architecture docs
- Expanded component directory tree in CONTRIBUTING.md with all 21 subdirectories now used
- Updated E2E test roadmap: 78 → 83 tests, 16 → 18 suites; added Phase 15 (Prompt Library)
- Corrected port allocation: docs claimed 3000+100, actual is 10000+10 (blocks of 10 ports)
- Added missing `FURY_PORT` environment variable to environment docs

## Details
Comprehensive documentation audit found several discrepancies between the actual codebase and documentation claims. All numbers, architecture descriptions, and technical claims have been verified against the current implementation and corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)