### PR TITLE
Poll git changes every 3s while Changes panel is visible

### DIFF
--- a/src/components/sidebar/ChangesPanel.test.tsx
+++ b/src/components/sidebar/ChangesPanel.test.tsx
@@ -416,6 +416,72 @@ describe("ChangesPanel", () => {
   });
 });
 
+// ─── Polling behavior ──────────────────────────────────────────────────────────────────
+describe("ChangesPanel - polling", () => {
+  const wsContext = { id: "ws-1", type: "workspace" as const };
+  const repoContext = { id: "repo-1", type: "repo" as const };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls loadDiff every 3 seconds for workspace context", () => {
+    useDiffStore.setState({
+      diffResults: { "ws-1": { files: [], totalAdditions: 0, totalDeletions: 0 } },
+    });
+    render(<ChangesPanel context={wsContext} />);
+    mockLoadDiff.mockClear();
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(mockLoadDiff).toHaveBeenCalledWith("ws-1");
+
+    mockLoadDiff.mockClear();
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(mockLoadDiff).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("polls loadRepoDiff every 3 seconds for repo context", () => {
+    useDiffStore.setState({
+      diffResults: { "repo-1": { files: [], totalAdditions: 0, totalDeletions: 0 } },
+    });
+    render(<ChangesPanel context={repoContext} />);
+    mockLoadRepoDiff.mockClear();
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(mockLoadRepoDiff).toHaveBeenCalledWith("repo-1");
+  });
+
+  it("clears interval on unmount", () => {
+    useDiffStore.setState({
+      diffResults: { "ws-1": { files: [], totalAdditions: 0, totalDeletions: 0 } },
+    });
+    const { unmount } = render(<ChangesPanel context={wsContext} />);
+    mockLoadDiff.mockClear();
+
+    unmount();
+
+    act(() => { vi.advanceTimersByTime(6000); });
+    expect(mockLoadDiff).not.toHaveBeenCalled();
+  });
+
+  it("uses loadDiff not refresh for polling (preserves patch preview cache)", () => {
+    useDiffStore.setState({
+      diffResults: { "ws-1": { files: [], totalAdditions: 0, totalDeletions: 0 } },
+    });
+    render(<ChangesPanel context={wsContext} />);
+    mockLoadDiff.mockClear();
+    mockRefresh.mockClear();
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(mockLoadDiff).toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});
+
 // ─── PrStatusBar sub-component (rendered inside ChangesPanel for workspace context) ──
 describe("PrStatusBar", () => {
   const wsContext = { id: "ws-1", type: "workspace" as const };

--- a/src/components/sidebar/ChangesPanel.tsx
+++ b/src/components/sidebar/ChangesPanel.tsx
@@ -251,6 +251,21 @@ export function ChangesPanel({ context }: Props) {
     }
   }, [agentStatus, context.type, contextId]);
 
+  // Poll for changes every 3s while the panel is visible.
+  // Uses loadDiff/loadRepoDiff (not refresh) to avoid clearing patch preview cache.
+  // Inflight dedup in the store prevents overlapping requests.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const store = useDiffStore.getState();
+      if (context.type === "workspace") {
+        store.loadDiff(contextId);
+      } else {
+        store.loadRepoDiff(contextId);
+      }
+    }, 3_000);
+    return () => clearInterval(interval);
+  }, [context.type, contextId]);
+
   const handleFileClick = (filePath: string) => {
     const store = useDiffStore.getState();
     if (context.type === "workspace") {


### PR DESCRIPTION
## Summary
- Fixes #85: Git changes panel was slow to update — only refreshed on mount, manual click, or agent idle
- Adds a 3-second `setInterval` in `ChangesPanel` that calls `loadDiff`/`loadRepoDiff` while the panel is mounted
- Uses `loadDiff` (not `refresh`) to avoid clearing patch preview cache on every tick
- Existing inflight dedup in `diffStore` prevents overlapping requests if git commands take >3s
- Conditional rendering in `RightSidebar` ensures polling stops when the tab is not visible

## Test plan
- [x] 4 new tests: polls workspace/repo every 3s, clears interval on unmount, uses loadDiff not refresh
- [x] All 43 ChangesPanel tests pass
- [x] Full test suite passes (2734/2735 — 1 pre-existing failure in PRPanel unrelated to this change)
- [ ] Manual: open Changes tab, modify a file externally, confirm panel updates within ~3s without clicking Refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)