### PR TITLE
Fix new worktree button selecting wrong project

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -111,7 +111,11 @@ export function Sidebar() {
             </button>
             <button
               onClick={() => {
-                if (repositories.length > 0) setNewWsRepoId(repositories[0].id);
+                if (repositories.length > 0) {
+                  const activeWs = workspaces.find((ws) => ws.id === activeWorkspaceId);
+                  const repoId = activeWs?.repoId ?? activeRepoId ?? repositories[0].id;
+                  setNewWsRepoId(repoId);
+                }
               }}
               className="rounded-md p-1 transition-colors hover:bg-[var(--bg-hover)]"
               style={{ color: "var(--text-muted)" }}
@@ -282,7 +286,11 @@ export function Sidebar() {
         <div className="flex items-center gap-3">
           <button
             onClick={() => {
-              if (repositories.length > 0) setNewWsRepoId(repositories[0].id);
+              if (repositories.length > 0) {
+                const activeWs = workspaces.find((ws) => ws.id === activeWorkspaceId);
+                const repoId = activeWs?.repoId ?? activeRepoId ?? repositories[0].id;
+                setNewWsRepoId(repoId);
+              }
             }}
             className="flex flex-1 items-center justify-center gap-2 rounded-lg py-2.5 text-sm font-medium transition-colors"
             style={{


### PR DESCRIPTION
## Summary
- Both "New Chat Worktree" buttons (header `+` and bottom green button) always used `repositories[0].id`, ignoring which project the user was currently viewing
- Now derives the repo from the active workspace's `repoId`, then `activeRepoId`, falling back to the first repo only when no context is available

## Test plan
- [ ] Open app with multiple repositories added
- [ ] Select a workspace in the second repo, click "New Chat Worktree" — dialog should open for that repo
- [ ] Click a repo's base branch item, click the `+` header button — dialog should open for that repo
- [ ] With no active context (home screen), click "New Chat Worktree" — should fall back to first repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)