### PR TITLE
Fix CI checks failing to parse unknown JSON field

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "fury"
-version = "1.7.1"
+version = "1.7.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/services/gh.rs
+++ b/src-tauri/src/services/gh.rs
@@ -117,6 +117,28 @@ pub fn get_pr_info(worktree_path: &Path) -> Result<Option<PrInfo>, AppError> {
     }))
 }
 
+/// Maps `gh pr checks` `state` field to `(status, conclusion)` to match the
+/// frontend's expected shape. The `state` field combines lifecycle and outcome:
+/// terminal states like SUCCESS/FAILURE map to status=COMPLETED with a conclusion,
+/// while in-progress states map to their lifecycle name with no conclusion.
+fn map_check_state(state: &str) -> (String, Option<String>) {
+    match state {
+        "SUCCESS" => ("COMPLETED".to_string(), Some("SUCCESS".to_string())),
+        "FAILURE" | "ERROR" | "STARTUP_FAILURE" => {
+            ("COMPLETED".to_string(), Some("FAILURE".to_string()))
+        }
+        "NEUTRAL" => ("COMPLETED".to_string(), Some("NEUTRAL".to_string())),
+        "CANCELLED" => ("COMPLETED".to_string(), Some("CANCELLED".to_string())),
+        "TIMED_OUT" => ("COMPLETED".to_string(), Some("TIMED_OUT".to_string())),
+        "SKIPPED" => ("COMPLETED".to_string(), Some("SKIPPED".to_string())),
+        "ACTION_REQUIRED" => ("COMPLETED".to_string(), Some("ACTION_REQUIRED".to_string())),
+        "STALE" => ("COMPLETED".to_string(), Some("STALE".to_string())),
+        "PENDING" | "EXPECTED" => ("IN_PROGRESS".to_string(), None),
+        "QUEUED" => ("QUEUED".to_string(), None),
+        other => (other.to_string(), None),
+    }
+}
+
 pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
     let gh = find_gh_binary()?;
     let output = platform::command(&gh)
@@ -124,7 +146,7 @@ pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
             "pr",
             "checks",
             "--json",
-            "name,state,conclusion,detailsUrl,description",
+            "name,state,link,description",
         ])
         .current_dir(worktree_path)
         .output()
@@ -149,29 +171,29 @@ pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
 
     Ok(raw
         .iter()
-        .map(|check| PrCheck {
-            name: check
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            status: check
+        .map(|check| {
+            let state = check
                 .get("state")
                 .and_then(|v| v.as_str())
-                .unwrap_or("UNKNOWN")
-                .to_string(),
-            conclusion: check
-                .get("conclusion")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-            details_url: check
-                .get("detailsUrl")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-            description: check
-                .get("description")
-                .and_then(|v| v.as_str())
-                .map(String::from),
+                .unwrap_or("UNKNOWN");
+            let (status, conclusion) = map_check_state(state);
+            PrCheck {
+                name: check
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                status,
+                conclusion,
+                details_url: check
+                    .get("link")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                description: check
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+            }
         })
         .collect())
 }


### PR DESCRIPTION
## Summary
- Replace invalid `conclusion` and `detailsUrl` fields in `gh pr checks --json` with valid `state` and `link` fields
- Add `map_check_state()` helper to derive `status`/`conclusion` from the single `state` field, preserving the frontend's expected shape
- Maps terminal states (SUCCESS, FAILURE, ERROR, etc.) to `COMPLETED` with appropriate conclusion, and in-progress states to `IN_PROGRESS`/`QUEUED` with no conclusion

Closes #96

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (252/253; 1 pre-existing failure in port_allocator unrelated to this change)
- [x] `npm test` passes (2734/2735; 1 flaky test in PRPanel unrelated to this change — passes when run individually)
- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)