### PR TITLE
Feature: Render images inline in chat messages

### DIFF
--- a/src-tauri/src/models/agent.rs
+++ b/src-tauri/src/models/agent.rs
@@ -106,6 +106,10 @@ pub enum ContentBlockEvent {
         tool_use_id: String,
         content: serde_json::Value,
     },
+    #[serde(rename = "image")]
+    Image {
+        source: serde_json::Value,
+    },
 }
 
 /// Lightweight event emitted to the frontend via Tauri events.
@@ -128,6 +132,10 @@ pub enum FrontendStreamEvent {
     ToolResult {
         tool_use_id: String,
         content: String,
+    },
+    AssistantImage {
+        media_type: String,
+        data: String,
     },
     Result {
         is_error: bool,

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -60,6 +60,10 @@ pub enum ContentBlock {
         tool_use_id: String,
         content: String,
     },
+    Image {
+        media_type: String,
+        data: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/services/claude_process.rs
+++ b/src-tauri/src/services/claude_process.rs
@@ -212,6 +212,7 @@ fn stream_event_detail(event: &FrontendStreamEvent) -> String {
             }
         }
         FrontendStreamEvent::PermissionRequest { tool_name, .. } => format!("permissionRequest:{}", tool_name),
+        FrontendStreamEvent::AssistantImage { media_type, .. } => format!("assistantImage:{}", media_type),
     }
 }
 
@@ -333,7 +334,9 @@ pub async fn spawn_and_stream(
                 continue;
             }
 
-            if let Some(mut frontend_event) = parse_stream_line(&line) {
+            let frontend_events = parse_stream_line(&line);
+            if !frontend_events.is_empty() {
+              for mut frontend_event in frontend_events {
                 if !session_id_captured {
                     session_id_captured =
                         try_capture_session_id(&frontend_event, &agents, ws_id);
@@ -355,6 +358,7 @@ pub async fn spawn_and_stream(
                 );
 
                 let _ = app_handle_stdout.emit(&event_name, &frontend_event);
+              }
             } else if !is_known_skippable_line(&line) {
                 let truncated = if line.len() > 200 { format!("{}...", &line[..200]) } else { line.clone() };
                 log_stream_event(&perf_metrics_stdout, ws_id, "line_parse_failed", Some(truncated));
@@ -521,7 +525,9 @@ pub async fn spawn_persistent(
                 continue;
             }
 
-            if let Some(mut frontend_event) = parse_stream_line(&line) {
+            let frontend_events = parse_stream_line(&line);
+            if !frontend_events.is_empty() {
+              for mut frontend_event in frontend_events {
                 if !session_id_captured {
                     session_id_captured =
                         try_capture_session_id(&frontend_event, &agents_stdout, ws_id);
@@ -557,6 +563,7 @@ pub async fn spawn_persistent(
                 }
 
                 let _ = app_handle_stdout.emit(&event_name, &frontend_event);
+              }
             } else if !is_known_skippable_line(&line) {
                 let truncated = if line.len() > 200 { format!("{}...", &line[..200]) } else { line.clone() };
                 log_stream_event(&perf_metrics_stdout, ws_id, "line_parse_failed", Some(truncated));
@@ -648,29 +655,39 @@ fn enrich_error_from_stderr(
 }
 
 /// Parse a single NDJSON line from Claude Code's stream output
-/// into a frontend-friendly event.
-pub fn parse_stream_line(line: &str) -> Option<FrontendStreamEvent> {
-    let raw: serde_json::Value = serde_json::from_str(line).ok()?;
+/// into frontend-friendly events. Returns a Vec because a single
+/// assistant message can contain multiple content blocks (text, tool_use, image, etc.).
+pub fn parse_stream_line(line: &str) -> Vec<FrontendStreamEvent> {
+    let raw: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
 
-    let event_type = raw.get("type")?.as_str()?;
+    let event_type = match raw.get("type").and_then(|v| v.as_str()) {
+        Some(t) => t,
+        None => return vec![],
+    };
 
     match event_type {
         "system" => {
             let session_id = raw.get("session_id").and_then(|v| v.as_str()).map(String::from);
             let message = raw.get("message").and_then(|v| v.as_str()).map(String::from);
-            Some(FrontendStreamEvent::System {
+            vec![FrontendStreamEvent::System {
                 session_id,
                 message,
-            })
+            }]
         }
         "assistant" => {
             // Extract content blocks from the message
-            let content = raw
+            let content = match raw
                 .get("message")
                 .and_then(|m| m.get("content"))
-                .and_then(|c| c.as_array())?;
+                .and_then(|c| c.as_array()) {
+                Some(c) => c,
+                None => return vec![],
+            };
 
-            // Process each content block
+            // Process each content block — emit all of them
             let mut events = Vec::new();
             for block in content {
                 let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
@@ -699,13 +716,23 @@ pub fn parse_stream_line(line: &str) -> Option<FrontendStreamEvent> {
                         }).unwrap_or_default();
                         events.push(FrontendStreamEvent::ToolResult { tool_use_id, content });
                     }
+                    "image" => {
+                        // Claude API image blocks: { type: "image", source: { type: "base64", media_type: "...", data: "..." } }
+                        if let Some(source) = block.get("source") {
+                            let media_type = source.get("media_type").and_then(|v| v.as_str()).unwrap_or("image/png").to_string();
+                            if let Some(data) = source.get("data").and_then(|v| v.as_str()) {
+                                events.push(FrontendStreamEvent::AssistantImage {
+                                    media_type,
+                                    data: data.to_string(),
+                                });
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
 
-            // Return the first event (most assistant messages have one content block)
-            // For multi-block messages, we emit them as separate events
-            events.into_iter().next()
+            events
         }
         "result" => {
             let is_error = raw.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false)
@@ -739,7 +766,7 @@ pub fn parse_stream_line(line: &str) -> Option<FrontendStreamEvent> {
             let output_tokens = usage.and_then(|u| u.get("output_tokens")).and_then(|v| v.as_u64());
             let cache_read_tokens = usage.and_then(|u| u.get("cache_read_input_tokens")).and_then(|v| v.as_u64());
             let cache_creation_tokens = usage.and_then(|u| u.get("cache_creation_input_tokens")).and_then(|v| v.as_u64());
-            Some(FrontendStreamEvent::Result {
+            vec![FrontendStreamEvent::Result {
                 is_error,
                 result,
                 session_id,
@@ -751,7 +778,7 @@ pub fn parse_stream_line(line: &str) -> Option<FrontendStreamEvent> {
                 output_tokens,
                 cache_read_tokens,
                 cache_creation_tokens,
-            })
+            }]
         }
         // Permission request: emitted when CLI needs user approval for a tool call
         "input_request" => {
@@ -767,12 +794,12 @@ pub fn parse_stream_line(line: &str) -> Option<FrontendStreamEvent> {
                 .or_else(|| raw.get("input"))
                 .cloned()
                 .unwrap_or(serde_json::Value::Null);
-            Some(FrontendStreamEvent::PermissionRequest {
+            vec![FrontendStreamEvent::PermissionRequest {
                 tool_name,
                 input,
-            })
+            }]
         }
-        _ => None,
+        _ => vec![],
     }
 }
 
@@ -785,8 +812,9 @@ mod tests {
     #[test]
     fn test_parse_system_event() {
         let line = r#"{"type":"system","session_id":"sess-123","message":"Connected"}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::System { session_id, message } => {
                 assert_eq!(session_id.as_deref(), Some("sess-123"));
                 assert_eq!(message.as_deref(), Some("Connected"));
@@ -798,8 +826,9 @@ mod tests {
     #[test]
     fn test_parse_assistant_text_event() {
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::AssistantText { text } => {
                 assert_eq!(text, "Hello world");
             }
@@ -810,8 +839,9 @@ mod tests {
     #[test]
     fn test_parse_tool_use_event() {
         let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"/tmp"}}]}}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::ToolUse { id, name, input } => {
                 assert_eq!(id, "tool-1");
                 assert_eq!(name, "read_file");
@@ -824,8 +854,9 @@ mod tests {
     #[test]
     fn test_parse_tool_result_event() {
         let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"file contents"}]}}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::ToolResult { tool_use_id, content } => {
                 assert_eq!(tool_use_id, "tool-1");
                 assert_eq!(content, "file contents");
@@ -835,10 +866,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_assistant_image_event() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBOR..."}}]}}"#;
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            FrontendStreamEvent::AssistantImage { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, "iVBOR...");
+            }
+            _ => panic!("Expected AssistantImage event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_multi_block_assistant_message() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Here is a screenshot:"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc123"}}]}}"#;
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], FrontendStreamEvent::AssistantText { .. }));
+        assert!(matches!(&events[1], FrontendStreamEvent::AssistantImage { .. }));
+    }
+
+    #[test]
     fn test_parse_result_event() {
         let line = r#"{"type":"result","is_error":false,"result":"Done","session_id":"sess-1","duration_ms":1000,"total_cost_usd":0.05,"num_turns":3,"usage":{"input_tokens":100,"output_tokens":200}}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::Result {
                 is_error,
                 result,
@@ -853,11 +908,11 @@ mod tests {
                 assert!(!is_error);
                 assert_eq!(result.as_deref(), Some("Done"));
                 assert_eq!(session_id.as_deref(), Some("sess-1"));
-                assert_eq!(duration_ms, Some(1000));
-                assert_eq!(total_cost_usd, Some(0.05));
-                assert_eq!(num_turns, Some(3));
-                assert_eq!(input_tokens, Some(100));
-                assert_eq!(output_tokens, Some(200));
+                assert_eq!(*duration_ms, Some(1000));
+                assert_eq!(*total_cost_usd, Some(0.05));
+                assert_eq!(*num_turns, Some(3));
+                assert_eq!(*input_tokens, Some(100));
+                assert_eq!(*output_tokens, Some(200));
             }
             _ => panic!("Expected Result event"),
         }
@@ -866,8 +921,9 @@ mod tests {
     #[test]
     fn test_parse_result_error_via_subtype() {
         let line = r#"{"type":"result","subtype":"error","result":"Something went wrong"}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::Result { is_error, .. } => assert!(is_error),
             _ => panic!("Expected Result event"),
         }
@@ -876,8 +932,9 @@ mod tests {
     #[test]
     fn test_parse_permission_request() {
         let line = r#"{"type":"input_request","tool":{"name":"bash","input":{"command":"ls"}}}"#;
-        let event = parse_stream_line(line).unwrap();
-        match event {
+        let events = parse_stream_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
             FrontendStreamEvent::PermissionRequest { tool_name, input } => {
                 assert_eq!(tool_name, "bash");
                 assert_eq!(input["command"], "ls");
@@ -887,14 +944,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_json_returns_none() {
-        assert!(parse_stream_line("not json").is_none());
+    fn test_parse_invalid_json_returns_empty() {
+        assert!(parse_stream_line("not json").is_empty());
     }
 
     #[test]
-    fn test_parse_unknown_type_returns_none() {
+    fn test_parse_unknown_type_returns_empty() {
         let line = r#"{"type":"unknown_event","data":"something"}"#;
-        assert!(parse_stream_line(line).is_none());
+        assert!(parse_stream_line(line).is_empty());
     }
 
     // --- is_known_skippable_line tests ---
@@ -915,7 +972,7 @@ mod tests {
     fn test_skippable_assistant_metadata() {
         // Assistant message without extractable content blocks (metadata-only)
         let line = r#"{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","stop_reason":"end_turn"}}"#;
-        assert!(parse_stream_line(line).is_none()); // not a frontend event
+        assert!(parse_stream_line(line).is_empty()); // not a frontend event
         assert!(is_known_skippable_line(line));      // but known-skippable
     }
 

--- a/src-tauri/src/services/codex_process.rs
+++ b/src-tauri/src/services/codex_process.rs
@@ -318,6 +318,25 @@ pub fn parse_codex_line(line: &str) -> Option<FrontendStreamEvent> {
                             .unwrap_or(serde_json::Value::Null);
                         return Some(FrontendStreamEvent::ToolUse { id, name, input });
                     }
+                    "image" => {
+                        // Codex image blocks: { type: "image", url: "..." } or base64 source
+                        if let Some(url) = block.get("url").and_then(|v| v.as_str()) {
+                            // URL-based image — encode as data with media_type hint
+                            return Some(FrontendStreamEvent::AssistantImage {
+                                media_type: "image/png".to_string(),
+                                data: url.to_string(),
+                            });
+                        }
+                        if let Some(source) = block.get("source") {
+                            let media_type = source.get("media_type").and_then(|v| v.as_str()).unwrap_or("image/png").to_string();
+                            if let Some(data) = source.get("data").and_then(|v| v.as_str()) {
+                                return Some(FrontendStreamEvent::AssistantImage {
+                                    media_type,
+                                    data: data.to_string(),
+                                });
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -564,8 +583,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_image_content_block_url() {
+        let line = r#"{"type":"item.message","item":{"role":"assistant","content":[{"type":"image","url":"https://example.com/img.png"}]}}"#;
+        let event = parse_codex_line(line).unwrap();
+        match event {
+            FrontendStreamEvent::AssistantImage { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, "https://example.com/img.png");
+            }
+            _ => panic!("Expected AssistantImage event"),
+        }
+    }
+
+    #[test]
     fn test_parse_unknown_content_block_type() {
-        let line = r#"{"type":"item.message","item":{"role":"assistant","content":[{"type":"image","url":"..."}]}}"#;
+        let line = r#"{"type":"item.message","item":{"role":"assistant","content":[{"type":"audio","data":"..."}]}}"#;
         assert!(parse_codex_line(line).is_none());
     }
 

--- a/src/components/chat/ImageLightbox.tsx
+++ b/src/components/chat/ImageLightbox.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useCallback } from "react";
+
+interface Props {
+  src: string;
+  alt?: string;
+  onClose: () => void;
+}
+
+export function ImageLightbox({ src, alt, onClose }: Props) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.80)" }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt ?? "Image preview"}
+    >
+      <img
+        src={src}
+        alt={alt ?? "Full size preview"}
+        className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain"
+        onClick={(e) => e.stopPropagation()}
+        draggable={false}
+      />
+    </div>
+  );
+}

--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -1,9 +1,10 @@
-import { Component, type ErrorInfo, type ReactNode, useMemo } from "react";
+import { Component, type ErrorInfo, type ReactNode, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import { extractCodeBlockInfo } from "../../lib/codeBlockFilePath";
 import { CodeBlockToolbar } from "./CodeBlockToolbar";
+import { ImageLightbox } from "./ImageLightbox";
 
 interface Props {
   content: string;
@@ -31,6 +32,33 @@ class MarkdownErrorBoundary extends Component<
   render() {
     return this.state.hasError ? this.props.fallback : this.props.children;
   }
+}
+
+function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  if (!src) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="my-2 block cursor-pointer overflow-hidden rounded-md border transition-opacity hover:opacity-80"
+        style={{ borderColor: "var(--border)" }}
+        onClick={() => setLightboxOpen(true)}
+      >
+        <img
+          src={src}
+          alt={alt ?? ""}
+          className="max-h-64 max-w-full object-contain"
+          draggable={false}
+        />
+      </button>
+      {lightboxOpen && (
+        <ImageLightbox src={src} alt={alt} onClose={() => setLightboxOpen(false)} />
+      )}
+    </>
+  );
 }
 
 /** Shared renderers that don't need context. */
@@ -117,6 +145,7 @@ const staticComponents: Partial<Components> = {
     </strong>
   ),
   em: ({ children }) => <em>{children}</em>,
+  img: ({ src, alt }) => <MarkdownImage src={src} alt={alt} />,
 };
 
 function buildComponents(

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -24,6 +24,7 @@ import type { ChatMessage, ContentBlock, ResponseMetadata } from "../../lib/taur
 import { readFileBase64 } from "../../lib/tauri";
 import { formatDuration, formatTokens, formatCost } from "../../lib/format";
 import { MarkdownContent } from "./MarkdownContent";
+import { ImageLightbox } from "./ImageLightbox";
 
 // --- Attachment parsing ---
 
@@ -99,12 +100,14 @@ interface ToolPair {
 
 type RenderGroup =
   | { kind: "text"; blocks: Array<ContentBlock & { type: "text" }> }
-  | { kind: "tools"; pairs: ToolPair[] };
+  | { kind: "tools"; pairs: ToolPair[] }
+  | { kind: "images"; blocks: Array<ContentBlock & { type: "image" }> };
 
 function groupContentBlocks(blocks: ContentBlock[]): RenderGroup[] {
   const groups: RenderGroup[] = [];
   let currentToolPairs: ToolPair[] = [];
   let currentTextBlocks: Array<ContentBlock & { type: "text" }> = [];
+  let currentImageBlocks: Array<ContentBlock & { type: "image" }> = [];
 
   const flushText = () => {
     if (currentTextBlocks.length > 0) {
@@ -120,14 +123,23 @@ function groupContentBlocks(blocks: ContentBlock[]): RenderGroup[] {
     }
   };
 
+  const flushImages = () => {
+    if (currentImageBlocks.length > 0) {
+      groups.push({ kind: "images", blocks: currentImageBlocks });
+      currentImageBlocks = [];
+    }
+  };
+
   for (const block of blocks) {
     switch (block.type) {
       case "text":
         flushTools();
+        flushImages();
         currentTextBlocks.push(block);
         break;
       case "toolUse":
         flushText();
+        flushImages();
         currentToolPairs.push({
           use: { id: block.id, name: block.name, input: block.input },
           result: null,
@@ -141,11 +153,17 @@ function groupContentBlocks(blocks: ContentBlock[]): RenderGroup[] {
         }
         break;
       }
+      case "image":
+        flushText();
+        flushTools();
+        currentImageBlocks.push(block);
+        break;
     }
   }
 
   flushText();
   flushTools();
+  flushImages();
   return groups;
 }
 
@@ -547,22 +565,61 @@ export function MessageBubble({ message, onRetry, contextId, contextType }: Prop
   // Assistant messages: plain output, no bubble, no avatar
   return (
     <div className="mb-3 text-[15px]" style={{ color: "var(--text-primary)" }}>
-      {groups.map((group, i) =>
-        group.kind === "text" ? (
-          group.blocks.map((block, j) => (
+      {groups.map((group, i) => {
+        if (group.kind === "text") {
+          return group.blocks.map((block, j) => (
             <div key={`${i}-${j}`} className="mb-1 break-words">
               <MarkdownContent content={block.text} contextId={contextId} contextType={contextType} />
             </div>
-          ))
-        ) : (
-          <ToolCallList key={i} pairs={group.pairs} />
-        ),
-      )}
+          ));
+        }
+        if (group.kind === "images") {
+          return <InlineImageGroup key={i} blocks={group.blocks} />;
+        }
+        return <ToolCallList key={i} pairs={group.pairs} />;
+      })}
       {message.metadata && <ResponseMetadataRow metadata={message.metadata} />}
     </div>
   );
 }
 
+
+function InlineImageGroup({ blocks }: { blocks: Array<ContentBlock & { type: "image" }> }) {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  return (
+    <>
+      <div className="my-2 flex flex-wrap gap-2">
+        {blocks.map((block, i) => {
+          const src = block.data.startsWith("data:")
+            ? block.data
+            : block.data.startsWith("http")
+              ? block.data
+              : `data:${block.mediaType};base64,${block.data}`;
+          return (
+            <button
+              key={i}
+              type="button"
+              className="cursor-pointer overflow-hidden rounded-md border transition-opacity hover:opacity-80"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => setLightboxSrc(src)}
+            >
+              <img
+                src={src}
+                alt={`Image ${i + 1}`}
+                className="max-h-64 max-w-full object-contain"
+                draggable={false}
+              />
+            </button>
+          );
+        })}
+      </div>
+      {lightboxSrc && (
+        <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+      )}
+    </>
+  );
+}
 
 function ResponseMetadataRow({ metadata }: { metadata: ResponseMetadata }) {
   const parts: string[] = [];

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -137,7 +137,8 @@ export type FrontendStreamEvent =
       cacheReadTokens?: number;
       cacheCreationTokens?: number;
     }
-  | { type: "permissionRequest"; toolName: string; input: unknown };
+  | { type: "permissionRequest"; toolName: string; input: unknown }
+  | { type: "assistantImage"; mediaType: string; data: string };
 
 // Chat types
 export type MessageRole = "user" | "assistant" | "system";
@@ -145,7 +146,8 @@ export type MessageRole = "user" | "assistant" | "system";
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "toolUse"; id: string; name: string; input: unknown }
-  | { type: "toolResult"; toolUseId: string; content: string };
+  | { type: "toolResult"; toolUseId: string; content: string }
+  | { type: "image"; mediaType: string; data: string };
 
 export interface ResponseMetadata {
   durationMs?: number;

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -314,6 +314,18 @@ function handleStreamEvent(
       break;
     }
 
+    case "assistantImage": {
+      // Finalize any streaming text first, then add image block
+      finalizeStreamingText(workspaceId, set, get);
+      const imgBlock: ContentBlock = {
+        type: "image",
+        mediaType: event.mediaType,
+        data: event.data,
+      };
+      appendContentBlock(workspaceId, imgBlock, set, get);
+      break;
+    }
+
     case "toolUse": {
       // Finalize any streaming text first, then add tool use block
       finalizeStreamingText(workspaceId, set, get);


### PR DESCRIPTION
## Summary
- Add `Image` content block type to backend (Rust) and frontend (TypeScript) for base64 image data from agent responses
- Parse image blocks in Claude and Codex stream parsers; change `parse_stream_line` to return `Vec` so multi-block messages (text + image) emit all events
- Handle `assistantImage` stream events in chatStore, render inline images in `MessageBubble` with click-to-expand lightbox
- Add custom `img` renderer to `MarkdownContent` so markdown image syntax (`![alt](url)`) also renders inline with lightbox
- Create `ImageLightbox` component (fullscreen overlay, close on backdrop click or Escape)

Closes #98

## Test plan
- [x] `cargo check` — compiles cleanly
- [x] `cargo test` — 254 passed (2 pre-existing port_allocator flakes)
- [x] `npm test` — 2732 passed (3 pre-existing ChecksPanel failures)
- [x] `npm run lint` — 0 errors
- [x] `npm run test:e2e` — 83 passed
- [ ] Manual: send a message that triggers an agent screenshot → verify image renders inline
- [ ] Manual: click an inline image → verify lightbox opens, Escape closes it
- [ ] Manual: verify markdown `![alt](url)` images render with lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)