### PR TITLE
Fix PR creation status bleeding across worktrees

### DIFF
--- a/src/components/pr/PRPanel.test.tsx
+++ b/src/components/pr/PRPanel.test.tsx
@@ -828,6 +828,23 @@ describe("PRPanel", () => {
     expect(startPollingSpy).not.toHaveBeenCalled();
   });
 
+  it("stops polling on unmount", async () => {
+    setupOpenPr({
+      checks: [
+        { name: "Build", conclusion: null, status: "IN_PROGRESS", detailsUrl: null, description: null },
+      ],
+    });
+    const stopPollingSpy = vi.spyOn(usePrStore.getState(), "stopPolling");
+    const { unmount } = render(<PRPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Build")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    expect(stopPollingSpy).toHaveBeenCalledWith("ws-1");
+  });
+
   // === Effects ===
 
   it("subscribes and loads PR info on mount", async () => {

--- a/src/components/pr/PRPanel.tsx
+++ b/src/components/pr/PRPanel.tsx
@@ -260,6 +260,9 @@ function PRStatusView({
     if (hasPendingChecks) {
       usePrStore.getState().startPolling(workspaceId);
     }
+    return () => {
+      usePrStore.getState().stopPolling(workspaceId);
+    };
   }, [hasPendingChecks, workspaceId]);
 
   return (

--- a/src/components/sidebar/ChangesPanel.tsx
+++ b/src/components/sidebar/ChangesPanel.tsx
@@ -112,6 +112,9 @@ function PrStatusBar({ workspaceId }: { workspaceId: string }) {
     if (hasPr && hasPendingChecks) {
       usePrStore.getState().startPolling(workspaceId);
     }
+    return () => {
+      usePrStore.getState().stopPolling(workspaceId);
+    };
   }, [hasPr, hasPendingChecks, workspaceId]);
 
   const prLink = hasPr && prInfo?.prUrl ? (

--- a/src/components/sidebar/ChecksPanel.test.tsx
+++ b/src/components/sidebar/ChecksPanel.test.tsx
@@ -831,6 +831,23 @@ describe("ChecksPanel", () => {
     expect(startPollingSpy).not.toHaveBeenCalled();
   });
 
+  it("stops polling on unmount", async () => {
+    setupOpenPr({
+      checks: [
+        { name: "Build", conclusion: null, status: "IN_PROGRESS", detailsUrl: null, description: null },
+      ],
+    });
+    const stopPollingSpy = vi.spyOn(usePrStore.getState(), "stopPolling");
+    const { unmount } = render(<ChecksPanel workspaceId="ws-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Build")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    expect(stopPollingSpy).toHaveBeenCalledWith("ws-1");
+  });
+
   // === Edge cases ===
 
   it("handles checks with mixed conclusions", async () => {

--- a/src/components/sidebar/ChecksPanel.tsx
+++ b/src/components/sidebar/ChecksPanel.tsx
@@ -551,6 +551,9 @@ export function ChecksPanel({ workspaceId }: Props) {
     if (hasPendingChecks || hasInProgressRuns) {
       usePrStore.getState().startPolling(workspaceId);
     }
+    return () => {
+      usePrStore.getState().stopPolling(workspaceId);
+    };
   }, [hasPendingChecks, hasInProgressRuns, workspaceId]);
 
   const handleFix = async () => {

--- a/src/stores/prStore.test.ts
+++ b/src/stores/prStore.test.ts
@@ -183,6 +183,126 @@ describe("prStore - unsubscribe", () => {
   });
 });
 
+describe("prStore - subscribe/unsubscribe race condition", () => {
+  // Each test resets the listen mock to avoid leftover mockImplementationOnce
+  // entries from previous tests (vi.clearAllMocks does not clear them).
+
+  it("unsubscribe during in-flight subscribe cancels and cleans up first listener", async () => {
+    vi.mocked(listen).mockReset();
+
+    let resolveFirst!: (v: () => void) => void;
+    const unlisten1 = vi.fn();
+
+    vi.mocked(listen).mockImplementationOnce(
+      () => new Promise((r) => { resolveFirst = r; }),
+    );
+
+    const subscribePromise = usePrStore.getState().subscribe("ws-1");
+
+    // Unsubscribe while subscribe is awaiting the first listen
+    usePrStore.getState().unsubscribe("ws-1");
+
+    // Resolve the first listen — subscribe should detect cancellation
+    resolveFirst(unlisten1);
+    await subscribePromise;
+
+    // First listener should be cleaned up, second never acquired
+    expect(unlisten1).toHaveBeenCalled();
+    expect(usePrStore.getState().subscriptions["ws-1"]).toBeUndefined();
+  });
+
+  it("unsubscribe between first and second await cleans up both listeners", async () => {
+    vi.mocked(listen).mockReset();
+
+    let resolveFirst!: (v: () => void) => void;
+    let resolveSecond!: (v: () => void) => void;
+    const unlisten1 = vi.fn();
+    const unlisten2 = vi.fn();
+
+    vi.mocked(listen)
+      .mockImplementationOnce(
+        () => new Promise((r) => { resolveFirst = r; }),
+      )
+      .mockImplementationOnce(
+        () => new Promise((r) => { resolveSecond = r; }),
+      );
+
+    const subscribePromise = usePrStore.getState().subscribe("ws-1");
+
+    // Resolve first listen so subscribe proceeds to second await
+    resolveFirst(unlisten1);
+    await Promise.resolve();
+
+    // Unsubscribe between the two awaits
+    usePrStore.getState().unsubscribe("ws-1");
+
+    // Resolve second listen
+    resolveSecond(unlisten2);
+    await subscribePromise;
+
+    // Both unlisten fns should have been called
+    expect(unlisten1).toHaveBeenCalled();
+    expect(unlisten2).toHaveBeenCalled();
+    expect(usePrStore.getState().subscriptions["ws-1"]).toBeUndefined();
+  });
+
+  it("cancelled event handler does not update store", async () => {
+    vi.mocked(listen).mockReset();
+
+    let updatedHandler: ((event: { payload: unknown }) => void) | undefined;
+    const unlisten1 = vi.fn();
+    const unlisten2 = vi.fn();
+
+    vi.mocked(listen).mockImplementation(async (_channel, handler) => {
+      const ch = String(_channel);
+      if (ch.startsWith("pr-updated:")) {
+        updatedHandler = handler as (event: { payload: unknown }) => void;
+      }
+      return ch.includes("updated") ? unlisten1 : unlisten2;
+    });
+
+    await usePrStore.getState().subscribe("ws-1");
+
+    // Now unsubscribe (cancels the token used by event handlers)
+    usePrStore.getState().unsubscribe("ws-1");
+
+    // Simulate an event arriving on the orphaned listener before unlisten takes effect
+    updatedHandler!({ payload: makePrInfo({ prNumber: 999, title: "Orphaned" }) });
+
+    // Store should NOT have been updated because the handler's token is cancelled
+    expect(usePrStore.getState().prInfo["ws-1"]).toBeUndefined();
+  });
+
+  it("re-subscribe after cancel works correctly", async () => {
+    vi.mocked(listen).mockReset();
+
+    let resolveFirst!: (v: () => void) => void;
+    const unlisten1 = vi.fn();
+
+    vi.mocked(listen).mockImplementationOnce(
+      () => new Promise((r) => { resolveFirst = r; }),
+    );
+
+    const subscribePromise = usePrStore.getState().subscribe("ws-1");
+
+    // Cancel it
+    usePrStore.getState().unsubscribe("ws-1");
+    resolveFirst(unlisten1);
+    await subscribePromise;
+
+    // Now re-subscribe fresh
+    const unlisten3 = vi.fn();
+    const unlisten4 = vi.fn();
+    vi.mocked(listen)
+      .mockResolvedValueOnce(unlisten3)
+      .mockResolvedValueOnce(unlisten4);
+
+    await usePrStore.getState().subscribe("ws-1");
+
+    expect(usePrStore.getState().subscriptions["ws-1"]).toEqual([unlisten3, unlisten4]);
+  });
+});
+
 describe("prStore - loadPrInfo", () => {
   it("loads PR info, reviews, and comments via combined endpoint", async () => {
     const info = makePrInfo();

--- a/src/stores/prStore.ts
+++ b/src/stores/prStore.ts
@@ -55,6 +55,11 @@ const _inflightPrInfo = new Set<string>();
 const _inflightReviews = new Set<string>();
 const _inflightWorkflowRuns = new Set<string>();
 
+// Cancel tokens for in-flight subscribe calls. When unsubscribe is called
+// while subscribe is still awaiting, the token is marked cancelled so
+// subscribe cleans up acquired listeners on resume instead of storing them.
+const _subscribeTokens = new Map<string, { cancelled: boolean }>();
+
 export const usePrStore = create<PrStore>((set, get) => ({
   prInfo: {},
   reviews: {},
@@ -70,24 +75,46 @@ export const usePrStore = create<PrStore>((set, get) => ({
   subscribe: async (workspaceId: string) => {
     if (get().subscriptions[workspaceId]) return;
 
+    // Cancel any in-flight subscribe for this workspace
+    const existing = _subscribeTokens.get(workspaceId);
+    if (existing) existing.cancelled = true;
+
+    const token = { cancelled: false };
+    _subscribeTokens.set(workspaceId, token);
+
     const unlistenUpdated = await listen<PrInfo>(
       `pr-updated:${workspaceId}`,
       (event) => {
+        if (token.cancelled) return;
         set((state) => ({
           prInfo: { ...state.prInfo, [workspaceId]: event.payload },
         }));
       },
     );
 
+    if (token.cancelled) {
+      unlistenUpdated();
+      _subscribeTokens.delete(workspaceId);
+      return;
+    }
+
     const unlistenMerged = await listen<MergeResult>(
       `pr-merged:${workspaceId}`,
       () => {
-        // Reload PR info after merge
+        if (token.cancelled) return;
         get().loadPrInfo(workspaceId);
         get().stopPolling(workspaceId);
       },
     );
 
+    if (token.cancelled) {
+      unlistenUpdated();
+      unlistenMerged();
+      _subscribeTokens.delete(workspaceId);
+      return;
+    }
+
+    // Keep token in map so unsubscribe can cancel event handlers later
     set((state) => ({
       subscriptions: {
         ...state.subscriptions,
@@ -97,6 +124,14 @@ export const usePrStore = create<PrStore>((set, get) => ({
   },
 
   unsubscribe: (workspaceId: string) => {
+    // Cancel the token so in-flight subscribes bail out and
+    // already-registered event handlers no-op on future events.
+    const token = _subscribeTokens.get(workspaceId);
+    if (token) {
+      token.cancelled = true;
+      _subscribeTokens.delete(workspaceId);
+    }
+
     const unsubs = get().subscriptions[workspaceId];
     if (unsubs) {
       unsubs.forEach((fn) => fn());


### PR DESCRIPTION
## Summary
- Fixed race condition in `prStore.subscribe`/`unsubscribe` where async subscribe could leave orphaned Tauri event listeners when switching workspaces quickly, causing PR creation status to bleed across worktrees
- Added cancel token pattern using module-level `Map` to coordinate async subscribe with sync unsubscribe — tokens guard event handler callbacks and enable early cleanup on cancellation
- Added `useEffect` cleanup returns (`stopPolling`) to `ChecksPanel`, `PRPanel`, and `ChangesPanel` to prevent polling from persisting after component unmount

## Test plan
- [x] 4 new race condition tests in `prStore.test.ts` (cancel during subscribe, cancel between awaits, cancelled handler no-op, re-subscribe after cancel)
- [x] 2 new polling cleanup tests in `ChecksPanel.test.tsx` and `PRPanel.test.tsx` (verify `stopPolling` called on unmount)
- [x] All 2740 unit tests pass (1 pre-existing failure unrelated to changes)
- [x] All 83 E2E tests pass
- [ ] Manual: create PR in workspace A, switch to workspace B, verify no loading/status indicators bleed

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)