### PR TITLE
Fix stop exit styling, stale timer, and add attention indicator

### DIFF
--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -927,6 +927,70 @@ describe("Sidebar", () => {
     });
   });
 
+  // --- Needs attention indicator ---
+  describe("Needs attention indicator", () => {
+    it("shows accent border and pulsing dot when workspace needs attention", () => {
+      useRepositoryStore.setState({ repositories: [makeRepo()] });
+      useWorkspaceStore.setState({
+        workspaces: [makeWorkspace()],
+        activeWorkspaceId: null,
+      });
+      useAgentStore.setState({
+        agents: { "ws-1": { workspaceId: "ws-1", status: "Idle" } as any },
+        needsAttention: { "ws-1": true },
+      });
+      render(<Sidebar />);
+
+      const wsName = screen.getByText("Feature Work");
+      const wsDiv = wsName.closest(".group")! as HTMLElement;
+      expect(wsDiv.style.border).toBe("1px solid var(--accent)");
+      const dot = wsDiv.querySelector(".animate-pulse");
+      expect(dot).not.toBeNull();
+      expect(dot).toHaveStyle({ backgroundColor: "var(--accent)" });
+    });
+
+    it("clears attention indicator when workspace is clicked", () => {
+      const clearNeedsAttention = vi.fn();
+      const setActive = vi.fn();
+      useRepositoryStore.setState({ repositories: [makeRepo()] });
+      useWorkspaceStore.setState({
+        workspaces: [makeWorkspace()],
+        activeWorkspaceId: null,
+        setActive,
+      });
+      useAgentStore.setState({
+        agents: { "ws-1": { workspaceId: "ws-1", status: "Idle" } as any },
+        needsAttention: { "ws-1": true },
+        clearNeedsAttention,
+      });
+      render(<Sidebar />);
+
+      const wsName = screen.getByText("Feature Work");
+      const wsDiv = wsName.closest(".group")!;
+      fireEvent.click(wsDiv);
+
+      expect(clearNeedsAttention).toHaveBeenCalledWith("ws-1");
+      expect(setActive).toHaveBeenCalledWith("ws-1");
+    });
+
+    it("does not show attention indicator when needsAttention is false", () => {
+      useRepositoryStore.setState({ repositories: [makeRepo()] });
+      useWorkspaceStore.setState({
+        workspaces: [makeWorkspace()],
+        activeWorkspaceId: null,
+      });
+      useAgentStore.setState({
+        agents: { "ws-1": { workspaceId: "ws-1", status: "Idle" } as any },
+        needsAttention: { "ws-1": false },
+      });
+      render(<Sidebar />);
+
+      const wsName = screen.getByText("Feature Work");
+      const wsDiv = wsName.closest(".group")! as HTMLElement;
+      expect(wsDiv.style.border).toBe("1px solid var(--border)");
+    });
+  });
+
   // --- Inactive repo branch styling ---
   describe("Inactive repo branch styling", () => {
     it("does not have active background for inactive repo branch", () => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -357,6 +357,7 @@ function RepoBranchItem({
   onClick: () => void;
 }) {
   const agentStatus = useAgentStore((s) => s.getStatus(repoId));
+  const attention = useAgentStore((s) => s.needsAttention[repoId] ?? false);
   const isRunning = agentStatus === "Running";
   const isAgentError =
     typeof agentStatus === "object" && "Error" in agentStatus;
@@ -367,23 +368,29 @@ function RepoBranchItem({
       ? "var(--error)"
       : "var(--text-muted)";
 
+  const handleClick = () => {
+    if (attention) useAgentStore.getState().clearNeedsAttention(repoId);
+    onClick();
+  };
+
   return (
     <div
-      onClick={onClick}
+      onClick={handleClick}
       className="group mx-3 my-1.5 cursor-pointer rounded-lg px-4 py-3.5 text-left text-sm transition-colors hover:bg-[var(--bg-hover)]"
       style={{
         backgroundColor: isActive ? "var(--bg-surface)" : "transparent",
-        border: isActive
+        border: isActive || attention
           ? "1px solid var(--accent)"
           : "1px solid var(--border)",
+        boxShadow: attention && !isActive ? "0 0 0 1px var(--accent)" : undefined,
         color: "var(--text-primary)",
       }}
     >
       {/* Row 1: status dot + name */}
       <div className="flex items-center gap-2">
         <span
-          className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${isRunning ? "animate-pulse" : ""}`}
-          style={{ backgroundColor: dotColor }}
+          className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${isRunning || attention ? "animate-pulse" : ""}`}
+          style={{ backgroundColor: attention ? "var(--accent)" : dotColor }}
         />
         <span className="truncate font-semibold">{branch}</span>
       </div>
@@ -428,11 +435,19 @@ function WorkspaceItem({
   onArchive: () => void;
 }) {
   const agentStatus = useAgentStore((s) => s.getStatus(id));
+  const attention = useAgentStore((s) => s.needsAttention[id] ?? false);
   const isRunning = agentStatus === "Running";
   const isAgentError =
     typeof agentStatus === "object" && "Error" in agentStatus;
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState(name);
+
+  // Periodically re-render so relativeTime stays accurate
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 30000);
+    return () => clearInterval(id);
+  }, []);
 
   const dotColor = isRunning
     ? "var(--success)"
@@ -456,23 +471,29 @@ function WorkspaceItem({
     setEditing(false);
   };
 
+  const handleClick = () => {
+    if (attention) useAgentStore.getState().clearNeedsAttention(id);
+    onClick();
+  };
+
   return (
     <div
-      onClick={onClick}
+      onClick={handleClick}
       className="group mx-3 my-1.5 cursor-pointer rounded-lg px-4 py-3.5 text-left text-sm transition-colors hover:bg-[var(--bg-hover)]"
       style={{
         backgroundColor: isActive ? "var(--bg-surface)" : "transparent",
-        border: isActive
+        border: isActive || attention
           ? "1px solid var(--accent)"
           : "1px solid var(--border)",
+        boxShadow: attention && !isActive ? "0 0 0 1px var(--accent)" : undefined,
         color: "var(--text-primary)",
       }}
     >
       {/* Row 1: status dot + name */}
       <div className="flex items-center gap-2">
         <span
-          className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${isRunning ? "animate-pulse" : ""}`}
-          style={{ backgroundColor: dotColor }}
+          className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${isRunning || attention ? "animate-pulse" : ""}`}
+          style={{ backgroundColor: attention ? "var(--accent)" : dotColor }}
         />
         {editing ? (
           <input

--- a/src/components/terminal/RunPanel.test.tsx
+++ b/src/components/terminal/RunPanel.test.tsx
@@ -151,4 +151,25 @@ describe("RunPanel", () => {
     const exitText = screen.getByText("Exit: 0");
     expect(exitText).toHaveStyle({ color: "var(--success)" });
   });
+
+  it("shows 'Stopped' with muted styling when user stopped the script", () => {
+    useScriptStore.setState({
+      exitCodes: { "ws-1:run": 1 },
+      userStopped: { "ws-1:run": true },
+    });
+    render(<RunPanel context={{ id: "ws-1", type: "workspace" }} />);
+    const stoppedText = screen.getByText("Stopped");
+    expect(stoppedText).toHaveStyle({ color: "var(--text-muted)" });
+    expect(screen.queryByText("Exit: 1")).not.toBeInTheDocument();
+  });
+
+  it("shows success styling for exit code 0 even when userStopped is true", () => {
+    useScriptStore.setState({
+      exitCodes: { "ws-1:run": 0 },
+      userStopped: { "ws-1:run": true },
+    });
+    render(<RunPanel context={{ id: "ws-1", type: "workspace" }} />);
+    const exitText = screen.getByText("Exit: 0");
+    expect(exitText).toHaveStyle({ color: "var(--success)" });
+  });
 });

--- a/src/components/terminal/RunPanel.tsx
+++ b/src/components/terminal/RunPanel.tsx
@@ -20,6 +20,9 @@ export function RunPanel({ context }: RunPanelProps) {
   const exitCode = useScriptStore(
     (s) => s.exitCodes[`${contextId}:run`],
   );
+  const userStopped = useScriptStore(
+    (s) => s.userStopped[`${contextId}:run`] ?? false,
+  );
 
   useEffect(() => {
     const store = useScriptStore.getState();
@@ -69,10 +72,14 @@ export function RunPanel({ context }: RunPanelProps) {
             <span
               style={{
                 color:
-                  exitCode === 0 ? "var(--success)" : "var(--error)",
+                  exitCode === 0
+                    ? "var(--success)"
+                    : userStopped
+                      ? "var(--text-muted)"
+                      : "var(--error)",
               }}
             >
-              Exit: {exitCode}
+              {userStopped && exitCode !== 0 ? "Stopped" : `Exit: ${exitCode}`}
             </span>
           )}
           {running && (

--- a/src/components/terminal/SetupPanel.test.tsx
+++ b/src/components/terminal/SetupPanel.test.tsx
@@ -137,4 +137,24 @@ describe("SetupPanel", () => {
     render(<SetupPanel context={{ id: "ws-1", type: "workspace" }} />);
     expect(screen.getByText("Exit: 0")).toHaveStyle({ color: "var(--success)" });
   });
+
+  it("shows 'Stopped' with muted styling when user stopped the script", () => {
+    useScriptStore.setState({
+      exitCodes: { "ws-1:setup": 1 },
+      userStopped: { "ws-1:setup": true },
+    });
+    render(<SetupPanel context={{ id: "ws-1", type: "workspace" }} />);
+    const stoppedText = screen.getByText("Stopped");
+    expect(stoppedText).toHaveStyle({ color: "var(--text-muted)" });
+    expect(screen.queryByText("Exit: 1")).not.toBeInTheDocument();
+  });
+
+  it("shows success styling for exit code 0 even when userStopped is true", () => {
+    useScriptStore.setState({
+      exitCodes: { "ws-1:setup": 0 },
+      userStopped: { "ws-1:setup": true },
+    });
+    render(<SetupPanel context={{ id: "ws-1", type: "workspace" }} />);
+    expect(screen.getByText("Exit: 0")).toHaveStyle({ color: "var(--success)" });
+  });
 });

--- a/src/components/terminal/SetupPanel.tsx
+++ b/src/components/terminal/SetupPanel.tsx
@@ -20,6 +20,9 @@ export function SetupPanel({ context }: Props) {
   const exitCode = useScriptStore(
     (s) => s.exitCodes[`${contextId}:setup`],
   );
+  const userStopped = useScriptStore(
+    (s) => s.userStopped[`${contextId}:setup`] ?? false,
+  );
 
   useEffect(() => {
     const id = requestAnimationFrame(() => {
@@ -73,10 +76,14 @@ export function SetupPanel({ context }: Props) {
             <span
               style={{
                 color:
-                  exitCode === 0 ? "var(--success)" : "var(--error)",
+                  exitCode === 0
+                    ? "var(--success)"
+                    : userStopped
+                      ? "var(--text-muted)"
+                      : "var(--error)",
               }}
             >
-              Exit: {exitCode}
+              {userStopped && exitCode !== 0 ? "Stopped" : `Exit: ${exitCode}`}
             </span>
           )}
           {running && (

--- a/src/stores/agentStore.test.ts
+++ b/src/stores/agentStore.test.ts
@@ -17,7 +17,7 @@ import {
 const mockListen = vi.mocked(listen);
 
 beforeEach(() => {
-  useAgentStore.setState({ agents: {}, subscriptions: {} });
+  useAgentStore.setState({ agents: {}, subscriptions: {}, needsAttention: {} });
   vi.clearAllMocks();
 });
 
@@ -222,5 +222,61 @@ describe("agentStore - fetchStatus", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     await useAgentStore.getState().fetchStatus("ws-1");
     // Should not throw
+  });
+});
+
+describe("agentStore - needsAttention", () => {
+  it("sets needsAttention when agent transitions from Running to Idle", async () => {
+    const mockUnlisten = vi.fn();
+    mockListen.mockResolvedValueOnce(mockUnlisten);
+    await useAgentStore.getState().subscribe("ws-1");
+
+    // Set initial state to Running
+    useAgentStore.setState({
+      agents: {
+        "ws-1": { workspaceId: "ws-1", status: "Running" } as any,
+      },
+    });
+
+    // Simulate event callback with Idle status
+    const callback = mockListen.mock.calls[0][1] as (event: any) => void;
+    callback({ payload: { status: "Idle" } });
+
+    expect(useAgentStore.getState().needsAttention["ws-1"]).toBe(true);
+  });
+
+  it("does not set needsAttention for Idle to Idle transition", async () => {
+    const mockUnlisten = vi.fn();
+    mockListen.mockResolvedValueOnce(mockUnlisten);
+    await useAgentStore.getState().subscribe("ws-1");
+
+    // No agent info yet, getStatus returns "Idle" by default
+    const callback = mockListen.mock.calls[0][1] as (event: any) => void;
+    callback({ payload: { status: "Idle" } });
+
+    expect(useAgentStore.getState().needsAttention["ws-1"]).toBeUndefined();
+  });
+
+  it("does not set needsAttention for Running to Error transition", async () => {
+    const mockUnlisten = vi.fn();
+    mockListen.mockResolvedValueOnce(mockUnlisten);
+    await useAgentStore.getState().subscribe("ws-1");
+
+    useAgentStore.setState({
+      agents: {
+        "ws-1": { workspaceId: "ws-1", status: "Running" } as any,
+      },
+    });
+
+    const callback = mockListen.mock.calls[0][1] as (event: any) => void;
+    callback({ payload: { status: { Error: "something broke" } } });
+
+    expect(useAgentStore.getState().needsAttention["ws-1"]).toBeUndefined();
+  });
+
+  it("clears needsAttention via clearNeedsAttention", () => {
+    useAgentStore.setState({ needsAttention: { "ws-1": true } });
+    useAgentStore.getState().clearNeedsAttention("ws-1");
+    expect(useAgentStore.getState().needsAttention["ws-1"]).toBe(false);
   });
 });

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -13,10 +13,12 @@ import { pushStreamEvent } from "../lib/ipcInstrumentation";
 interface AgentStore {
   agents: Record<string, AgentInfo>;
   subscriptions: Record<string, UnlistenFn>;
+  needsAttention: Record<string, boolean>;
 
   getStatus: (workspaceId: string) => AgentStatus;
   subscribe: (workspaceId: string) => Promise<void>;
   unsubscribe: (workspaceId: string) => void;
+  clearNeedsAttention: (workspaceId: string) => void;
   sendMessage: (
     contextId: string,
     message: string,
@@ -38,6 +40,7 @@ interface AgentStore {
 export const useAgentStore = create<AgentStore>((set, get) => ({
   agents: {},
   subscriptions: {},
+  needsAttention: {},
 
   getStatus: (workspaceId: string): AgentStatus => {
     return get().agents[workspaceId]?.status ?? "Idle";
@@ -53,6 +56,7 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
         const newStatus = event.payload.status;
         const prevStatus = get().agents[workspaceId]?.status ?? "Idle";
         pushStreamEvent(workspaceId, "status_changed", `${JSON.stringify(prevStatus)} -> ${JSON.stringify(newStatus)}`);
+        const becameIdle = prevStatus === "Running" && newStatus === "Idle";
         set((state) => ({
           agents: {
             ...state.agents,
@@ -62,6 +66,9 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
               status: newStatus,
             } as AgentInfo,
           },
+          ...(becameIdle
+            ? { needsAttention: { ...state.needsAttention, [workspaceId]: true } }
+            : {}),
         }));
       },
     );
@@ -80,6 +87,12 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
         return { subscriptions: rest };
       });
     }
+  },
+
+  clearNeedsAttention: (workspaceId: string) => {
+    set((state) => ({
+      needsAttention: { ...state.needsAttention, [workspaceId]: false },
+    }));
   },
 
   sendMessage: async (

--- a/src/stores/scriptStore.ts
+++ b/src/stores/scriptStore.ts
@@ -14,6 +14,7 @@ interface ScriptStore {
   output: Record<string, string[]>;
   running: Record<string, boolean>;
   exitCodes: Record<string, number | null>;
+  userStopped: Record<string, boolean>;
   subscriptions: Record<string, UnlistenFn[]>;
 
   subscribe: (contextId: string, kind: ScriptKind) => Promise<void>;
@@ -35,6 +36,7 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
   output: {},
   running: {},
   exitCodes: {},
+  userStopped: {},
   subscriptions: {},
 
   subscribe: async (workspaceId: string, kind: ScriptKind) => {
@@ -90,6 +92,7 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
     set((state) => ({
       running: { ...state.running, [k]: true },
       exitCodes: { ...state.exitCodes, [k]: null },
+      userStopped: { ...state.userStopped, [k]: false },
       output: { ...state.output, [k]: [] },
     }));
     try {
@@ -106,6 +109,10 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
   },
 
   stopScript: async (workspaceId: string, kind: ScriptKind) => {
+    const k = key(workspaceId, kind);
+    set((state) => ({
+      userStopped: { ...state.userStopped, [k]: true },
+    }));
     try {
       await stopScriptCmd(workspaceId, kind);
     } catch (e) {
@@ -118,6 +125,7 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
     set((state) => ({
       running: { ...state.running, [k]: true },
       exitCodes: { ...state.exitCodes, [k]: null },
+      userStopped: { ...state.userStopped, [k]: false },
       output: { ...state.output, [k]: [] },
     }));
     try {
@@ -134,6 +142,10 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
   },
 
   stopRepoScript: async (repoId: string, kind: ScriptKind) => {
+    const k = key(repoId, kind);
+    set((state) => ({
+      userStopped: { ...state.userStopped, [k]: true },
+    }));
     try {
       await stopRepoScriptCmd(repoId, kind);
     } catch (e) {
@@ -146,6 +158,7 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
     set((state) => ({
       output: { ...state.output, [k]: [] },
       exitCodes: { ...state.exitCodes, [k]: null },
+      userStopped: { ...state.userStopped, [k]: false },
     }));
   },
 


### PR DESCRIPTION
## Summary
- **#104** — Show "Stopped" in muted/grey styling instead of red "Exit: 1" when user clicks Stop. Tracks `userStopped` in `scriptStore` so RunPanel and SetupPanel can style accordingly.
- **#108** — Add `setInterval` in `WorkspaceItem` to re-render every 30s so `relativeTime()` stays accurate when switching between worktrees.
- **#101** — Track `needsAttention` in `agentStore` when an agent transitions from Running → Idle. Shows accent border, box-shadow glow, and pulsing dot on sidebar worktree items. Clears when the user clicks the worktree.

## Test plan
- [x] All 2752 existing tests pass
- [x] New tests for user-stopped exit code styling (RunPanel, SetupPanel)
- [x] New tests for `needsAttention` transitions and clearing (agentStore)
- [x] New tests for attention indicator visibility and click-to-clear (Sidebar)
- [ ] Manual: Run a script, click Stop → see "Stopped" in grey
- [ ] Manual: Create worktree, wait 1+ min, switch away/back → timer shows accurate elapsed time
- [ ] Manual: Start agent, switch worktree, wait for finish → sidebar item glows with accent border

Closes #104, closes #108, closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)