### PR TITLE
Fix chat persistence and PR creation with uncommitted changes

### DIFF
--- a/src-tauri/src/commands/pr.rs
+++ b/src-tauri/src/commands/pr.rs
@@ -39,6 +39,12 @@ pub async fn create_pr(
 
     tokio::task::spawn_blocking(move || {
         gh_svc::check_gh_auth()?;
+
+        // Auto-commit uncommitted changes before pushing
+        if gh_svc::has_uncommitted_changes(&worktree_path)? {
+            gh_svc::stage_and_commit(&worktree_path, &title)?;
+        }
+
         gh_svc::push_branch(&worktree_path, &branch)?;
 
         let mut pr_info = gh_svc::create_pr(
@@ -137,6 +143,11 @@ pub async fn push_changes(
     };
 
     tokio::task::spawn_blocking(move || {
+        // Auto-commit uncommitted changes before pushing
+        if gh_svc::has_uncommitted_changes(&worktree_path)? {
+            gh_svc::stage_and_commit(&worktree_path, "Update changes")?;
+        }
+
         gh_svc::push_branch(&worktree_path, &branch)?;
 
         // Parallelize PR info + checks fetch after push

--- a/src-tauri/src/services/gh.rs
+++ b/src-tauri/src/services/gh.rs
@@ -47,6 +47,57 @@ pub fn push_branch(worktree_path: &Path, branch: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Check if the worktree has uncommitted changes (staged or unstaged).
+pub fn has_uncommitted_changes(worktree_path: &Path) -> Result<bool, AppError> {
+    let output = platform::command("git")
+        .args(["status", "--porcelain"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::GitError(format!("Failed to run git status: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(AppError::GitError(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    Ok(!output.stdout.is_empty())
+}
+
+/// Stage all changes and create a commit with the given message.
+pub fn stage_and_commit(worktree_path: &Path, message: &str) -> Result<(), AppError> {
+    let add_output = platform::command("git")
+        .args(["add", "-A"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::GitError(format!("Failed to run git add: {}", e)))?;
+
+    if !add_output.status.success() {
+        return Err(AppError::GitError(format!(
+            "git add failed: {}",
+            String::from_utf8_lossy(&add_output.stderr)
+        )));
+    }
+
+    let commit_output = platform::command("git")
+        .args(["commit", "-m", message])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| AppError::GitError(format!("Failed to run git commit: {}", e)))?;
+
+    if !commit_output.status.success() {
+        let stderr = String::from_utf8_lossy(&commit_output.stderr);
+        let stdout = String::from_utf8_lossy(&commit_output.stdout);
+        if stderr.contains("nothing to commit") || stdout.contains("nothing to commit") {
+            return Ok(());
+        }
+        return Err(AppError::GitError(format!("git commit failed: {}", stderr)));
+    }
+
+    Ok(())
+}
+
 pub fn create_pr(
     worktree_path: &Path,
     title: &str,
@@ -142,12 +193,7 @@ fn map_check_state(state: &str) -> (String, Option<String>) {
 pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
     let gh = find_gh_binary()?;
     let output = platform::command(&gh)
-        .args([
-            "pr",
-            "checks",
-            "--json",
-            "name,state,link,description",
-        ])
+        .args(["pr", "checks", "--json", "name,state,link,description"])
         .current_dir(worktree_path)
         .output()
         .map_err(|e| AppError::PrError(format!("Failed to run gh pr checks: {}", e)))?;
@@ -185,10 +231,7 @@ pub fn get_pr_checks(worktree_path: &Path) -> Result<Vec<PrCheck>, AppError> {
                     .to_string(),
                 status,
                 conclusion,
-                details_url: check
-                    .get("link")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
+                details_url: check.get("link").and_then(|v| v.as_str()).map(String::from),
                 description: check
                     .get("description")
                     .and_then(|v| v.as_str())
@@ -973,4 +1016,63 @@ pub fn rerun_workflow(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn init_test_repo() -> tempfile::TempDir {
+        let dir = tempdir().unwrap();
+        platform::command("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        platform::command("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        platform::command("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        platform::command("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_has_uncommitted_changes_clean() {
+        let dir = init_test_repo();
+        assert!(!has_uncommitted_changes(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn test_has_uncommitted_changes_with_new_file() {
+        let dir = init_test_repo();
+        fs::write(dir.path().join("test.txt"), "hello").unwrap();
+        assert!(has_uncommitted_changes(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn test_stage_and_commit() {
+        let dir = init_test_repo();
+        fs::write(dir.path().join("test.txt"), "hello").unwrap();
+        stage_and_commit(dir.path(), "test commit").unwrap();
+        assert!(!has_uncommitted_changes(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn test_stage_and_commit_nothing_to_commit() {
+        let dir = init_test_repo();
+        stage_and_commit(dir.path(), "empty commit").unwrap();
+    }
 }

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -489,6 +489,33 @@ describe("chatStore - stream events", () => {
     });
   });
 
+  it("persists new assistant message created by toolUse", () => {
+    vi.mocked(saveChatMessage).mockClear();
+    handleEvent({
+      payload: {
+        type: "toolUse",
+        id: "tool-1",
+        name: "write_file",
+        input: {},
+      },
+    });
+    expect(saveChatMessage).toHaveBeenCalled();
+  });
+
+  it("persists assistant message when toolUse appends to existing message", () => {
+    handleEvent({ payload: { type: "assistantText", text: "thinking..." } });
+    vi.mocked(saveChatMessage).mockClear();
+    handleEvent({
+      payload: {
+        type: "toolUse",
+        id: "tool-1",
+        name: "read_file",
+        input: { path: "/test" },
+      },
+    });
+    expect(saveChatMessage).toHaveBeenCalled();
+  });
+
   it("handles result event - persists last assistant message", () => {
     // First create an assistant message via streaming text
     handleEvent({ payload: { type: "assistantText", text: "final answer" } });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -520,10 +520,8 @@ function appendContentBlock(
         [workspaceId]: [...messages.slice(0, -1), updated],
       },
     }));
-    // Persist after each tool result for crash durability
-    if (block.type === "toolResult") {
-      persistMessage(workspaceId, updated);
-    }
+    // Persist after every content block for crash durability
+    persistMessage(workspaceId, updated);
   } else {
     const msg: ChatMessage = {
       id: crypto.randomUUID(),
@@ -537,6 +535,7 @@ function appendContentBlock(
         [workspaceId]: [...(state.messages[workspaceId] ?? []), msg],
       },
     }));
+    persistMessage(workspaceId, msg);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs affecting core workflows:

- **#88 Chat messages lost on app restart** — The persistence layer in `appendContentBlock()` only saved `toolResult` blocks, losing `toolUse` blocks and newly created assistant messages. Now all content blocks and new messages are persisted immediately.

- **#97 PR creation fails with "No commits"** — `create_pr` assumed all changes were already committed, causing failures when new branches had zero commits ahead. Now auto-commits uncommitted changes before pushing using the PR title as the commit message.

## Testing

- ✅ 2765+ frontend tests pass (added 2 new chat persistence tests)
- ✅ 260 backend tests pass (added 4 new git helper tests)
- ✅ Type checking (cargo check) passes
- ✅ All E2E tests pass

## Commits

- Chat persistence: unconditionally persist all assistant message blocks in `appendContentBlock()`
- PR creation: add `has_uncommitted_changes()` and `stage_and_commit()` to gh service, wire into both `create_pr` and `push_changes` commands