### PR TITLE
Add clickable terminal links and follow-up messages (#102, #105)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tauri-apps/plugin-shell": "^2",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@xterm/addon-fit": "^0.10",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^5",
         "cmdk": "^1",
         "lucide-react": "^0.575.0",
@@ -3659,6 +3660,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.10",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^5",
     "cmdk": "^1",
     "lucide-react": "^0.575.0",

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -745,6 +745,39 @@ pub async fn respond_to_permission(
 }
 
 #[tauri::command]
+pub async fn send_followup_message(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    message: String,
+) -> Result<(), AppError> {
+    let id: Uuid = workspace_id
+        .parse()
+        .map_err(|_| AppError::WorkspaceNotFound(Uuid::nil()))?;
+
+    // Try agent_stdins first (non-persistent mode)
+    let regular_stdin = state.agent_stdins.lock().unwrap().remove(&id);
+    if let Some(mut stdin) = regular_stdin {
+        let write_result = claude_process::write_message(&mut stdin, &message).await;
+        state.agent_stdins.lock().unwrap().insert(id, stdin);
+        write_result?;
+        return Ok(());
+    }
+
+    // Try persistent_agents
+    let persistent_handle = state.persistent_agents.lock().unwrap().remove(&id);
+    if let Some(mut handle) = persistent_handle {
+        let write_result = claude_process::write_message(&mut handle.stdin, &message).await;
+        state.persistent_agents.lock().unwrap().insert(id, handle);
+        write_result?;
+        return Ok(());
+    }
+
+    Err(AppError::AgentError(
+        "No stdin handle found for this agent".to_string(),
+    ))
+}
+
+#[tauri::command]
 pub async fn stop_agent(
     app: tauri::AppHandle,
     state: State<'_, AppState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run() {
             commands::agent::get_agent_status,
             commands::agent::clear_session,
             commands::agent::respond_to_permission,
+            commands::agent::send_followup_message,
             // Chat commands
             commands::chat::save_chat_message,
             commands::chat::list_chat_messages,

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -324,7 +324,7 @@ export function Composer({ contextId, contextType, agentStatus, onSend, onStop, 
 
   const isRunning = agentStatus === "Running";
   const isStopping = agentStatus === "Stopping";
-  const canSend = (text.trim().length > 0 || droppedFiles.length > 0) && !isRunning && !isStopping;
+  const canSend = (text.trim().length > 0 || droppedFiles.length > 0) && !isStopping;
 
   // Reset model selection when agent type changes
   useEffect(() => {
@@ -882,7 +882,7 @@ export function Composer({ contextId, contextType, agentStatus, onSend, onStop, 
 
   let placeholderText: string;
   if (isRunning) {
-    placeholderText = "Waiting for response...";
+    placeholderText = "Send a follow-up message...";
   } else if (isPlanApproval) {
     placeholderText = "Enter your plan adjustments here...";
   } else {

--- a/src/components/terminal/TerminalView.test.tsx
+++ b/src/components/terminal/TerminalView.test.tsx
@@ -30,6 +30,15 @@ vi.mock("@xterm/addon-fit", () => {
   return { FitAddon: FitAddonClass };
 });
 
+vi.mock("@xterm/addon-web-links", () => {
+  const WebLinksAddonClass = vi.fn();
+  return { WebLinksAddon: WebLinksAddonClass };
+});
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn().mockResolvedValue(undefined),
+}));
+
 let listenCallback: ((event: any) => void) | null = null;
 const mockUnlisten = vi.fn();
 vi.mock("@tauri-apps/api/event", () => ({
@@ -88,9 +97,9 @@ describe("TerminalView", () => {
     expect(mockOpen).toHaveBeenCalled();
   });
 
-  it("loads FitAddon", () => {
+  it("loads FitAddon and WebLinksAddon", () => {
     render(<TerminalView terminalId="t-1" />);
-    expect(mockLoadAddon).toHaveBeenCalled();
+    expect(mockLoadAddon).toHaveBeenCalledTimes(2);
   });
 
   it("listens for terminal output events", () => {

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { listen } from "@tauri-apps/api/event";
 import {
   writeTerminal,
@@ -53,6 +54,11 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
 
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
+    term.loadAddon(
+      new WebLinksAddon((_event, uri) => {
+        import("@tauri-apps/plugin-shell").then(({ open }) => open(uri));
+      }),
+    );
     term.open(containerRef.current);
 
     // Initial fit

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -258,6 +258,13 @@ export async function sendMessage(request: SendMessageRequest): Promise<void> {
   return invoke("send_message", { request });
 }
 
+export async function sendFollowupMessage(
+  workspaceId: string,
+  message: string,
+): Promise<void> {
+  return invoke("send_followup_message", { workspaceId, message });
+}
+
 export async function stopAgent(workspaceId: string): Promise<void> {
   return invoke("stop_agent", { workspaceId });
 }

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -5,6 +5,7 @@ import {
   type AgentStatus,
   type AgentStatusEvent,
   sendMessage as sendMessageCmd,
+  sendFollowupMessage as sendFollowupCmd,
   stopAgent as stopAgentCmd,
   getAgentStatus,
 } from "../lib/tauri";
@@ -104,6 +105,13 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
     disablePlanMode?: boolean,
   ) => {
     try {
+      // If agent is already running, send as a follow-up via stdin
+      const status = get().agents[contextId]?.status;
+      if (status === "Running") {
+        await sendFollowupCmd(contextId, message);
+        return;
+      }
+
       const request =
         contextType === "workspace"
           ? { workspaceId: contextId, message, model: model || undefined, disableThinking, disablePlanMode }


### PR DESCRIPTION
## Summary
- Implement clickable URLs in terminal output via xterm.js WebLinksAddon
- Enable follow-up messages while agent is processing without spawning new process
- Messages write directly to agent stdin, matching existing permission response flow

## Testing
- All 2765 unit tests pass
- Rust backend compiles cleanly
- Terminal view tests updated for new addon mocking