### PR TITLE
feat: persist active context and session IDs across app restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ src-tauri/target/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 
 # Coverage & mutation testing
 coverage/

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -172,10 +172,22 @@ pub(crate) fn parse_agent_workspace_id(workspace_id: &str) -> Result<Uuid, AppEr
 pub(crate) fn activate_agent(
     agents: &mut HashMap<Uuid, AgentInfo>,
     context_id: Uuid,
+    db: &std::sync::Mutex<Option<crate::db::Database>>,
 ) -> Option<String> {
     let agent = agents
         .entry(context_id)
-        .or_insert_with(|| AgentInfo::new(context_id));
+        .or_insert_with(|| {
+            let mut info = AgentInfo::new(context_id);
+            // Restore session_id from DB if available (survives app restart)
+            if let Ok(guard) = db.lock() {
+                if let Some(db) = guard.as_ref() {
+                    if let Ok(Some(sid)) = db.get_session_id(&context_id.to_string()) {
+                        info.session_id = Some(sid);
+                    }
+                }
+            }
+            info
+        });
     agent.status = AgentStatus::Running;
     agent.started_at = Some(chrono::Utc::now());
     agent.session_id.clone()
@@ -331,7 +343,7 @@ pub async fn send_message(
     // Get or create agent info, extract session_id
     let session_id = {
         let mut agents = state.agents.lock().unwrap();
-        activate_agent(&mut agents, context_id)
+        activate_agent(&mut agents, context_id, &state.db)
     };
 
     // Create checkpoint before sending message (workspace mode only)
@@ -454,7 +466,7 @@ pub async fn send_message(
             let mut sidecar_guard = state.agent_sidecar.lock().unwrap();
             if sidecar_guard.is_none() {
                 *sidecar_guard = Some(
-                    claude_process::start_sidecar(&app, Arc::clone(&state.agents))
+                    claude_process::start_sidecar(&app, Arc::clone(&state.agents), Arc::clone(&state.db))
                         .inspect_err(|_| {
                             reset_agent_on_error(&state.agents, &app, context_id);
                         })?
@@ -475,6 +487,7 @@ pub async fn send_message(
             env_vars: Some(env_vars),
             additional_dirs: Some(linked_dirs.iter().map(|d| d.to_string_lossy().to_string()).collect()),
             disable_thinking: Some(disable_thinking),
+            disable_plan_mode: Some(disable_plan_mode),
         };
 
         // Take the handle out of the Mutex, send the command (async), then put it back.
@@ -719,6 +732,7 @@ pub async fn send_followup_message(
         env_vars: None,
         additional_dirs: None,
         disable_thinking: None,
+        disable_plan_mode: None,
     };
 
     let mut handle = {
@@ -853,8 +867,9 @@ mod tests {
     fn test_activate_agent_new() {
         let mut agents = HashMap::new();
         let id = Uuid::new_v4();
+        let db: Mutex<Option<crate::db::Database>> = Mutex::new(None);
 
-        let session = activate_agent(&mut agents, id);
+        let session = activate_agent(&mut agents, id, &db);
         assert!(session.is_none()); // new agent has no session
         assert_eq!(agents.get(&id).unwrap().status, AgentStatus::Running);
         assert!(agents.get(&id).unwrap().started_at.is_some());
@@ -869,7 +884,8 @@ mod tests {
         agent.status = AgentStatus::Idle;
         agents.insert(id, agent);
 
-        let session = activate_agent(&mut agents, id);
+        let db: Mutex<Option<crate::db::Database>> = Mutex::new(None);
+        let session = activate_agent(&mut agents, id, &db);
         assert_eq!(session, Some("sess-123".to_string()));
         assert_eq!(agents.get(&id).unwrap().status, AgentStatus::Running);
     }
@@ -1012,7 +1028,8 @@ mod tests {
         agent.status = AgentStatus::Error("previous crash".to_string());
         agents.insert(id, agent);
 
-        activate_agent(&mut agents, id);
+        let db: Mutex<Option<crate::db::Database>> = Mutex::new(None);
+        activate_agent(&mut agents, id, &db);
         assert_eq!(agents.get(&id).unwrap().status, AgentStatus::Running);
     }
 
@@ -1025,7 +1042,8 @@ mod tests {
         agent.status = AgentStatus::Idle;
         agents.insert(id, agent);
 
-        let session = activate_agent(&mut agents, id);
+        let db: Mutex<Option<crate::db::Database>> = Mutex::new(None);
+        let session = activate_agent(&mut agents, id, &db);
         assert_eq!(session, Some("my-session".to_string()));
         // session_id should still be there after activation
         assert_eq!(

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -421,7 +421,7 @@ pub async fn send_message(
         settings.system_prompt_additions.clone()
     };
 
-    let (disable_thinking, _disable_plan_mode) = extract_toggle_flags(&request);
+    let (disable_thinking, disable_plan_mode) = extract_toggle_flags(&request);
 
     // Validate working directory exists before spawning
     if let Err(e) = validate_working_dir(&working_dir) {

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -168,6 +168,28 @@ pub async fn update_app_settings(
 }
 
 #[tauri::command]
+pub async fn get_last_active_context(
+    state: State<'_, AppState>,
+) -> Result<(Option<String>, Option<String>), AppError> {
+    let db = state.db.lock().unwrap();
+    db.as_ref()
+        .ok_or_else(|| AppError::DbError("DB not initialized".into()))?
+        .get_last_active_context()
+}
+
+#[tauri::command]
+pub async fn save_last_active_context(
+    state: State<'_, AppState>,
+    workspace_id: Option<String>,
+    repo_id: Option<String>,
+) -> Result<(), AppError> {
+    let db = state.db.lock().unwrap();
+    db.as_ref()
+        .ok_or_else(|| AppError::DbError("DB not initialized".into()))?
+        .save_last_active_context(workspace_id.as_deref(), repo_id.as_deref())
+}
+
+#[tauri::command]
 pub async fn detect_cursorrules(
     state: State<'_, AppState>,
     repo_id: String,

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -255,5 +255,38 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     )
     .map_err(|e| AppError::DbError(e.to_string()))?;
 
+    // Remove FK constraint on chat_messages.workspace_id — this column stores both
+    // workspace IDs and repo IDs (for repo-mode chat), so the FK is incorrect.
+    // SQLite doesn't support DROP CONSTRAINT, so we recreate the table.
+    // The migration is idempotent: it checks if the FK still exists before running.
+    let has_fk: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM pragma_foreign_key_list('chat_messages') WHERE \"table\" = 'workspaces'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+
+    if has_fk {
+        conn.execute_batch(
+            "
+            CREATE TABLE chat_messages_new (
+                id TEXT UNIQUE,
+                workspace_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                display_text TEXT,
+                metadata TEXT
+            );
+            INSERT INTO chat_messages_new SELECT id, workspace_id, role, content, timestamp, display_text, metadata FROM chat_messages;
+            DROP TABLE chat_messages;
+            ALTER TABLE chat_messages_new RENAME TO chat_messages;
+            CREATE INDEX idx_chat_messages_workspace ON chat_messages(workspace_id);
+            ",
+        )
+        .map_err(|e| AppError::DbError(e.to_string()))?;
+    }
+
     Ok(())
 }

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -270,6 +270,7 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if has_fk {
         conn.execute_batch(
             "
+            BEGIN;
             CREATE TABLE chat_messages_new (
                 id TEXT UNIQUE,
                 workspace_id TEXT NOT NULL,
@@ -283,6 +284,7 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
             DROP TABLE chat_messages;
             ALTER TABLE chat_messages_new RENAME TO chat_messages;
             CREATE INDEX idx_chat_messages_workspace ON chat_messages(workspace_id);
+            COMMIT;
             ",
         )
         .map_err(|e| AppError::DbError(e.to_string()))?;

--- a/src-tauri/src/db/settings.rs
+++ b/src-tauri/src/db/settings.rs
@@ -206,6 +206,67 @@ impl Database {
         )?;
         Ok(())
     }
+
+    pub fn get_last_active_context(&self) -> Result<(Option<String>, Option<String>), AppError> {
+        let result = self.conn.query_row(
+            "SELECT value FROM app_settings WHERE key = 'last_active_context'",
+            [],
+            |row| row.get::<_, String>(0),
+        );
+        match result {
+            Ok(json) => {
+                let v: serde_json::Value =
+                    serde_json::from_str(&json).map_err(|e| AppError::DbError(e.to_string()))?;
+                let ws_id = v
+                    .get("workspaceId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let repo_id = v.get("repoId").and_then(|v| v.as_str()).map(String::from);
+                Ok((ws_id, repo_id))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok((None, None)),
+            Err(e) => Err(AppError::DbError(e.to_string())),
+        }
+    }
+
+    pub fn save_last_active_context(
+        &self,
+        workspace_id: Option<&str>,
+        repo_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        let json = serde_json::json!({
+            "workspaceId": workspace_id,
+            "repoId": repo_id,
+        });
+        self.conn.execute(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('last_active_context', ?1)",
+            rusqlite::params![json.to_string()],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_session_id(&self, context_id: &str) -> Result<Option<String>, AppError> {
+        let key = format!("session:{}", context_id);
+        let result = self.conn.query_row(
+            "SELECT value FROM app_settings WHERE key = ?1",
+            rusqlite::params![key],
+            |row| row.get::<_, String>(0),
+        );
+        match result {
+            Ok(sid) => Ok(Some(sid)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(AppError::DbError(e.to_string())),
+        }
+    }
+
+    pub fn save_session_id(&self, context_id: &str, session_id: &str) -> Result<(), AppError> {
+        let key = format!("session:{}", context_id);
+        self.conn.execute(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?1, ?2)",
+            rusqlite::params![key, session_id],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,6 +192,8 @@ pub fn run() {
             commands::mcp::import_cursor_config,
             commands::mcp::get_app_settings,
             commands::mcp::update_app_settings,
+            commands::mcp::get_last_active_context,
+            commands::mcp::save_last_active_context,
             commands::mcp::detect_cursorrules,
             commands::mcp::import_cursorrules,
             // LSP Plugin commands

--- a/src-tauri/src/services/claude_process/sidecar.rs
+++ b/src-tauri/src/services/claude_process/sidecar.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 use crate::error::AppError;
 use crate::models::agent::{AgentInfo, AgentStatus, FrontendStreamEvent};
 
-use super::stream::try_capture_session_id;
+use super::stream::try_capture_session_id_with_db;
+use crate::db::Database;
 
 /// Handle to the long-lived Node.js sidecar process.
 /// The sidecar wraps the Claude Agent SDK and communicates via NDJSON on stdin/stdout.
@@ -44,6 +45,8 @@ pub enum SidecarCommand {
         additional_dirs: Option<Vec<String>>,
         #[serde(rename = "disableThinking", skip_serializing_if = "Option::is_none")]
         disable_thinking: Option<bool>,
+        #[serde(rename = "disablePlanMode", skip_serializing_if = "Option::is_none")]
+        disable_plan_mode: Option<bool>,
     },
     PermissionResponse {
         id: String,
@@ -71,6 +74,7 @@ pub enum SidecarCommand {
 pub fn start_sidecar(
     app: &AppHandle,
     agents: Arc<Mutex<HashMap<Uuid, AgentInfo>>>,
+    db: Arc<Mutex<Option<Database>>>,
 ) -> Result<SidecarHandle, AppError> {
     let sidecar_path = find_sidecar_path(app)?;
 
@@ -110,13 +114,14 @@ pub fn start_sidecar(
         .state::<crate::state::app_state::AppState>()
         .pending_permissions
         .clone();
+    let db_clone = Arc::clone(&db);
     tokio::spawn(async move {
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
 
         while let Ok(Some(line)) = lines.next_line().await {
             if let Err(e) =
-                handle_sidecar_line(&line, &app_clone, &agents_clone, &pending_perms)
+                handle_sidecar_line(&line, &app_clone, &agents_clone, &pending_perms, &db_clone)
             {
                 eprintln!("[sidecar] Error handling line: {}", e);
             }
@@ -187,6 +192,7 @@ fn handle_sidecar_line(
     app: &AppHandle,
     agents: &Arc<Mutex<HashMap<Uuid, AgentInfo>>>,
     pending_permissions: &Arc<Mutex<HashMap<Uuid, FrontendStreamEvent>>>,
+    db: &Arc<Mutex<Option<Database>>>,
 ) -> Result<(), String> {
     let (workspace_id, raw) = parse_sidecar_line_id(line)?;
 
@@ -194,8 +200,8 @@ fn handle_sidecar_line(
     let events = super::parse_stream_line(line);
 
     for event in &events {
-        // Capture session_id from system/result events
-        try_capture_session_id(event, agents, workspace_id);
+        // Capture session_id from system/result events and persist to DB
+        try_capture_session_id_with_db(event, agents, workspace_id, Some(db));
 
         // Track pending permission requests so they can be re-emitted after HMR
         match event {
@@ -280,6 +286,7 @@ mod tests {
             env_vars: None,
             additional_dirs: None,
             disable_thinking: None,
+            disable_plan_mode: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"type\":\"query\""));
@@ -304,6 +311,7 @@ mod tests {
             env_vars: None,
             additional_dirs: Some(vec!["/extra".to_string()]),
             disable_thinking: Some(true),
+            disable_plan_mode: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         // All fields must use camelCase to match TypeScript protocol

--- a/src-tauri/src/services/claude_process/stream.rs
+++ b/src-tauri/src/services/claude_process/stream.rs
@@ -16,6 +16,16 @@ pub(crate) fn try_capture_session_id(
     agents: &Mutex<HashMap<Uuid, AgentInfo>>,
     workspace_id: Uuid,
 ) -> bool {
+    try_capture_session_id_with_db(event, agents, workspace_id, None)
+}
+
+/// Like `try_capture_session_id` but also persists to DB for cross-restart resume.
+pub(crate) fn try_capture_session_id_with_db(
+    event: &FrontendStreamEvent,
+    agents: &Mutex<HashMap<Uuid, AgentInfo>>,
+    workspace_id: Uuid,
+    db: Option<&Mutex<Option<crate::db::Database>>>,
+) -> bool {
     let sid = match event {
         FrontendStreamEvent::System { session_id, .. } => session_id.clone(),
         FrontendStreamEvent::Result { session_id, .. } => session_id.clone(),
@@ -24,7 +34,16 @@ pub(crate) fn try_capture_session_id(
     if let Some(sid) = sid {
         let mut lock = agents.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(agent) = lock.get_mut(&workspace_id) {
-            agent.session_id = Some(sid);
+            agent.session_id = Some(sid.clone());
+        }
+        drop(lock);
+        // Persist to DB so session survives app restart
+        if let Some(db_mutex) = db {
+            if let Ok(guard) = db_mutex.lock() {
+                if let Some(db) = guard.as_ref() {
+                    let _ = db.save_session_id(&workspace_id.to_string(), &sid);
+                }
+            }
         }
         true
     } else {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -163,6 +163,8 @@ vi.mock("./lib/tauri", () => ({
   listWorkspaces: vi.fn().mockResolvedValue([]),
   listen: vi.fn().mockResolvedValue(() => {}),
   detectLspSuggestions: vi.fn().mockResolvedValue([]),
+  getLastActiveContext: vi.fn().mockResolvedValue([null, null]),
+  saveLastActiveContext: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockApplyTheme = vi.fn();

--- a/src/components/settings/RepoSettingsPanel.test.tsx
+++ b/src/components/settings/RepoSettingsPanel.test.tsx
@@ -537,7 +537,7 @@ describe("RepoSettingsPanel", () => {
       expect(mockGetRepoSettings).toHaveBeenCalled();
     });
 
-    const worktreeInput = screen.getByPlaceholderText("Default: .worktrees/ (inside repo)");
+    const worktreeInput = screen.getByPlaceholderText("Default: .claude/worktrees/ (inside repo)");
     fireEvent.change(worktreeInput, { target: { value: "/custom/path" } });
     expect(worktreeInput).toHaveValue("/custom/path");
 
@@ -562,11 +562,11 @@ describe("RepoSettingsPanel", () => {
     });
     render(<RepoSettingsPanel repoId="r1" repoName="My Repo" onClose={vi.fn()} />);
     await waitFor(() => {
-      const worktreeInput = screen.getByPlaceholderText("Default: .worktrees/ (inside repo)");
+      const worktreeInput = screen.getByPlaceholderText("Default: .claude/worktrees/ (inside repo)");
       expect(worktreeInput).toHaveValue("/existing/path");
     });
 
-    const worktreeInput = screen.getByPlaceholderText("Default: .worktrees/ (inside repo)");
+    const worktreeInput = screen.getByPlaceholderText("Default: .claude/worktrees/ (inside repo)");
     fireEvent.change(worktreeInput, { target: { value: "" } });
 
     fireEvent.click(screen.getByText("Save"));

--- a/src/components/settings/RepoSettingsPanel.tsx
+++ b/src/components/settings/RepoSettingsPanel.tsx
@@ -173,7 +173,7 @@ export function RepoSettingsPanel({
                   worktreeBasePath: e.target.value || null,
                 }))
               }
-              placeholder="Default: .worktrees/ (inside repo)"
+              placeholder="Default: .claude/worktrees/ (inside repo)"
               className="w-full rounded px-2 py-1.5 font-mono text-xs"
               style={{
                 backgroundColor: "var(--bg-surface)",

--- a/src/components/settings/tabs/CopilotTab.tsx
+++ b/src/components/settings/tabs/CopilotTab.tsx
@@ -79,7 +79,7 @@ export function CopilotTab() {
       await open(uri);
     } catch {
       /* v8 ignore start -- fallback when Tauri shell plugin unavailable */
-      window.open(uri, "_blank");
+      globalThis.window?.open(uri, "_blank");
       /* v8 ignore stop */
     }
   };

--- a/src/lib/tauri/settings.ts
+++ b/src/lib/tauri/settings.ts
@@ -80,6 +80,18 @@ export async function updateAppSettings(
   return invoke("update_app_settings", { settings });
 }
 
+// Last active context persistence
+export async function getLastActiveContext(): Promise<[string | null, string | null]> {
+  return invoke<[string | null, string | null]>("get_last_active_context");
+}
+
+export async function saveLastActiveContext(
+  workspaceId: string | null,
+  repoId: string | null,
+): Promise<void> {
+  return invoke("save_last_active_context", { workspaceId, repoId });
+}
+
 // Claude Context indexing commands
 export async function indexRepository(repoId: string): Promise<void> {
   return invoke("index_repository", { repoId });

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -2849,9 +2849,9 @@ describe("chatStore - subscribe cancellation tokens", () => {
   });
 
   it("second subscribe cancels first token but both complete", async () => {
-    let loadCount = 0;
+    let _loadCount = 0;
     vi.mocked(listChatMessages).mockImplementation(async () => {
-      loadCount++;
+      _loadCount++;
       return [];
     });
     vi.mocked(listen).mockResolvedValue(() => {});

--- a/src/stores/workspaceStore.test.ts
+++ b/src/stores/workspaceStore.test.ts
@@ -17,6 +17,7 @@ vi.mock("../lib/tauri", () => ({
   setWorkspacePinned: vi.fn(),
   getLastActiveContext: vi.fn().mockResolvedValue([null, null]),
   saveLastActiveContext: vi.fn().mockResolvedValue(undefined),
+  listRepositories: vi.fn().mockResolvedValue([]),
 }));
 
 import { useWorkspaceStore } from "./workspaceStore";

--- a/src/stores/workspaceStore.test.ts
+++ b/src/stores/workspaceStore.test.ts
@@ -15,6 +15,8 @@ vi.mock("../lib/tauri", () => ({
   restoreWorkspace: vi.fn(),
   renameWorkspace: vi.fn(),
   setWorkspacePinned: vi.fn(),
+  getLastActiveContext: vi.fn().mockResolvedValue([null, null]),
+  saveLastActiveContext: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { useWorkspaceStore } from "./workspaceStore";

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -12,6 +12,7 @@ import {
   setWorkspacePinned,
   getLastActiveContext,
   saveLastActiveContext,
+  listRepositories,
 } from "../lib/tauri";
 import { useUIStore } from "./uiStore";
 import { useChatStore } from "./chatStore";
@@ -72,19 +73,24 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   loadWorkspaces: async () => {
     set({ loading: true, error: null });
     try {
-      // Fetch workspaces and last active context in parallel
-      const [workspaces, [savedWsId, savedRepoId]] = await Promise.all([
-        listWorkspaces(),
-        // Only restore if nothing is active yet (first load on app start)
-        get().activeWorkspaceId || get().activeRepoId
-          ? Promise.resolve([null, null] as [string | null, string | null])
-          : getLastActiveContext(),
-      ]);
+      // Fetch workspaces, repos, and last active context in parallel
+      const [workspaces, repositories, [savedWsId, savedRepoId]] =
+        await Promise.all([
+          listWorkspaces(),
+          listRepositories(),
+          // Only restore if nothing is active yet (first load on app start)
+          get().activeWorkspaceId || get().activeRepoId
+            ? Promise.resolve([null, null] as [string | null, string | null])
+            : getLastActiveContext(),
+        ]);
 
       // Restore saved active context if valid
       if (savedWsId && workspaces.some((w) => w.id === savedWsId)) {
         set({ workspaces, loading: false, activeWorkspaceId: savedWsId });
-      } else if (savedRepoId) {
+      } else if (
+        savedRepoId &&
+        repositories.some((r) => r.id === savedRepoId)
+      ) {
         set({ workspaces, loading: false, activeRepoId: savedRepoId });
       } else {
         set({ workspaces, loading: false });
@@ -183,11 +189,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
   restoreWs: async (id: string) => {
     try {
-      await restoreWorkspace(id);
-      const ws = get().archivedWorkspaces.find((w) => w.id === id);
+      const ws = await restoreWorkspace(id);
       set({
         archivedWorkspaces: get().archivedWorkspaces.filter((w) => w.id !== id),
-        workspaces: ws ? [...get().workspaces, ws] : get().workspaces,
+        workspaces: [...get().workspaces, ws],
       });
     } catch (e) {
       set({ error: String(e) });

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -10,6 +10,8 @@ import {
   restoreWorkspace,
   renameWorkspace,
   setWorkspacePinned,
+  getLastActiveContext,
+  saveLastActiveContext,
 } from "../lib/tauri";
 import { useUIStore } from "./uiStore";
 import { useChatStore } from "./chatStore";
@@ -28,6 +30,13 @@ function _cleanupWorkspace(workspaceId: string) {
   try { usePrStore.getState().unsubscribe(workspaceId); } catch (e) { console.warn(`[workspaceStore] pr cleanup failed for ${workspaceId}:`, e); }
   cleanupActivityTracking(workspaceId);
   cleanupNotificationTracking(workspaceId);
+}
+
+/** Fire-and-forget persist of the active context to the backend DB. */
+function _persistActiveContext(workspaceId: string | null, repoId: string | null) {
+  saveLastActiveContext(workspaceId, repoId).catch((e) => {
+    console.warn("[workspaceStore] failed to persist active context:", e);
+  });
 }
 
 interface WorkspaceStore {
@@ -63,8 +72,23 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   loadWorkspaces: async () => {
     set({ loading: true, error: null });
     try {
-      const workspaces = await listWorkspaces();
-      set({ workspaces, loading: false });
+      // Fetch workspaces and last active context in parallel
+      const [workspaces, [savedWsId, savedRepoId]] = await Promise.all([
+        listWorkspaces(),
+        // Only restore if nothing is active yet (first load on app start)
+        get().activeWorkspaceId || get().activeRepoId
+          ? Promise.resolve([null, null] as [string | null, string | null])
+          : getLastActiveContext(),
+      ]);
+
+      // Restore saved active context if valid
+      if (savedWsId && workspaces.some((w) => w.id === savedWsId)) {
+        set({ workspaces, loading: false, activeWorkspaceId: savedWsId });
+      } else if (savedRepoId) {
+        set({ workspaces, loading: false, activeRepoId: savedRepoId });
+      } else {
+        set({ workspaces, loading: false });
+      }
     } catch (e) {
       set({ error: String(e), loading: false });
     }
@@ -77,7 +101,9 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       set({
         workspaces: [...get().workspaces, ws],
         activeWorkspaceId: ws.id,
+        activeRepoId: null,
       });
+      _persistActiveContext(ws.id, null);
       return ws;
     } catch (e) {
       set({ error: String(e) });
@@ -103,6 +129,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         activeWorkspaceId: nextActive,
         activeRepoId: wasActive ? null : get().activeRepoId,
       });
+      if (wasActive) _persistActiveContext(nextActive, null);
 
       // Cross-store cleanup for the archived workspace
       _cleanupWorkspace(id);
@@ -126,6 +153,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         activeWorkspaceId: nextActive,
         activeRepoId: wasActive ? null : get().activeRepoId,
       });
+      if (wasActive) _persistActiveContext(nextActive, null);
 
       // Cross-store cleanup for the deleted workspace
       _cleanupWorkspace(id);
@@ -135,21 +163,13 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   },
 
   setActive: (id: string | null) => {
-    if (import.meta.env.DEV) {
-      if (id) sessionStorage.setItem("fury:activeWorkspaceId", id);
-      else sessionStorage.removeItem("fury:activeWorkspaceId");
-      sessionStorage.removeItem("fury:activeRepoId");
-    }
     set({ activeWorkspaceId: id, activeRepoId: null });
+    _persistActiveContext(id, null);
   },
 
   setActiveRepo: (id: string | null) => {
-    if (import.meta.env.DEV) {
-      if (id) sessionStorage.setItem("fury:activeRepoId", id);
-      else sessionStorage.removeItem("fury:activeRepoId");
-      sessionStorage.removeItem("fury:activeWorkspaceId");
-    }
     set({ activeRepoId: id, activeWorkspaceId: null });
+    _persistActiveContext(null, id);
   },
 
   loadArchivedWorkspaces: async () => {
@@ -163,12 +183,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
   restoreWs: async (id: string) => {
     try {
-      const ws = await restoreWorkspace(id);
+      await restoreWorkspace(id);
+      const ws = get().archivedWorkspaces.find((w) => w.id === id);
       set({
-        workspaces: [...get().workspaces, ws],
-        archivedWorkspaces: get().archivedWorkspaces.filter(
-          (w) => w.id !== id,
-        ),
+        archivedWorkspaces: get().archivedWorkspaces.filter((w) => w.id !== id),
+        workspaces: ws ? [...get().workspaces, ws] : get().workspaces,
       });
     } catch (e) {
       set({ error: String(e) });
@@ -204,4 +223,3 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     }
   },
 }));
-

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -169,11 +169,21 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   },
 
   setActive: (id: string | null) => {
+    if (import.meta.env.DEV) {
+      if (id) sessionStorage.setItem("fury:activeWorkspaceId", id);
+      else sessionStorage.removeItem("fury:activeWorkspaceId");
+      sessionStorage.removeItem("fury:activeRepoId");
+    }
     set({ activeWorkspaceId: id, activeRepoId: null });
     _persistActiveContext(id, null);
   },
 
   setActiveRepo: (id: string | null) => {
+    if (import.meta.env.DEV) {
+      if (id) sessionStorage.setItem("fury:activeRepoId", id);
+      else sessionStorage.removeItem("fury:activeRepoId");
+      sessionStorage.removeItem("fury:activeWorkspaceId");
+    }
     set({ activeRepoId: id, activeWorkspaceId: null });
     _persistActiveContext(null, id);
   },


### PR DESCRIPTION
## Summary
- **Session persistence**: Replace dev-only `sessionStorage` with DB-backed persistence for active workspace/repo context and agent session IDs, enabling session resume after app restart
- **DB migration**: Remove incorrect FK constraint on `chat_messages.workspace_id` (stores both workspace and repo IDs for repo-mode chat)
- **Sidecar protocol**: Add `disablePlanMode` field to `SidecarCommand::Query` for plan mode support
- **Worktree path**: Move default worktree directory from `.worktrees/` to `.claude/worktrees/`
- **Fix duplicate text**: Skip text blocks in assistant events (already streamed via `text_delta`)

## Test plan
- [ ] Verify active workspace/repo is restored after app restart
- [ ] Verify agent session ID survives app restart and resumes correctly
- [ ] Verify repo-mode chat messages work without FK violations
- [ ] Verify `npm test` passes
- [ ] Verify `cargo test` passes
- [ ] Run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)