### PR TITLE
feat: add 3-layer persistent memory system for AI agents

### DIFF
--- a/docs/core/memory.mdx
+++ b/docs/core/memory.mdx
@@ -1,0 +1,112 @@
+---
+title: Memory
+description: Persistent memory across agent sessions with semantic search
+---
+
+Fury's memory system lets your AI agent remember context across sessions — decisions made, patterns discovered, errors encountered, and preferences learned. Instead of starting fresh every conversation, the agent picks up where it left off.
+
+## How it works
+
+Memory operates in three layers, each serving a different purpose:
+
+### Layer 1: Context injection
+
+At the start of every session, Fury reads compressed memory snapshots from the database and prepends them to the system prompt. This gives the agent immediate awareness of past context without any tool calls.
+
+The context is organized by scope:
+
+| Scope | What it contains |
+|-------|-----------------|
+| **Global** | Your preferences across all projects |
+| **Repository** | Patterns shared across all branches in a repo |
+| **Workspace** | Branch-specific context for the current task |
+
+Cost: ~2-3K tokens per session (fixed).
+
+### Layer 2: Observation hooks
+
+During a session, Fury automatically extracts observations from tool results using SDK hooks:
+
+- **File changes** — Tracks which files were modified and what changed
+- **Errors** — Captures errors from bash commands
+- **Patterns** — Records significant commands (npm, cargo, git, docker, etc.)
+- **Decisions** — Extracts architectural choices from the agent's reasoning
+
+These observations are compressed at session end using deduplication and summarization, then persisted for future sessions.
+
+Cost: Zero tokens (runs in the sidecar process, not sent to the API).
+
+### Layer 3: Semantic search
+
+The agent can actively search and store memories on demand using MCP tools. With MemPalace enabled (the default), this provides 19 tools including:
+
+- **Semantic search** — Find relevant memories using vector similarity via ChromaDB
+- **Knowledge graph** — Query entity relationships with temporal awareness
+- **Palace navigation** — Browse memories organized by project and category
+- **Agent diary** — Per-agent notes that persist across sessions
+
+Without MemPalace, a basic keyword search fallback is used.
+
+## MemPalace
+
+[MemPalace](https://github.com/milla-jovovich/mempalace) is an open-source memory system that powers Layer 3's semantic search. It stores complete observations in a navigable "palace" structure backed by ChromaDB for vector search.
+
+### Setup
+
+MemPalace is enabled by default. Go to **Settings > Memory** to check status and configure.
+
+**Requirements:**
+- Python 3.9+
+- `mempalace` package (installable from the Settings page)
+
+If Python or MemPalace isn't available, Fury falls back to basic keyword search automatically.
+
+### Installing
+
+From **Settings > Memory**, click **Install MemPalace**. Fury will try these methods in order:
+
+1. `pipx install mempalace` (isolated, recommended)
+2. `uv tool install mempalace`
+3. `pip install --user mempalace`
+
+### Palace initialization
+
+The palace directory (default: `~/.mempalace/palace`) is created automatically on first use. You can also click **Initialize Palace** in Settings to set it up manually.
+
+### Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Enabled** | `true` | Toggle MemPalace on/off |
+| **Palace Path** | `~/.mempalace/palace` | Where ChromaDB and knowledge graph are stored |
+| **Python Command** | Auto-detected | Override the Python binary (e.g., `python3.11`) |
+
+### Data migration
+
+If you have existing memory from before MemPalace was enabled, click **Migrate Existing Memory** in Settings to import your SQLite snapshots into MemPalace drawers.
+
+## Scope mapping
+
+Fury maps its memory scopes to MemPalace's palace structure:
+
+| Fury concept | MemPalace equivalent |
+|-------------|---------------------|
+| Repository | Wing (e.g., `fury`) |
+| Category (decisions, patterns, errors) | Room (e.g., `decisions`) |
+| Global scope | Wing `_global` |
+| Workspace/branch | Drawer metadata |
+
+## Settings
+
+Configure memory from **Settings > Memory** (Brain icon). The page shows:
+
+- **Enable/disable** toggle for MemPalace
+- **Status indicators** for Python, MemPalace package, and palace directory
+- **Setup actions** — Install, initialize, and migrate
+- **Path configuration** — Palace directory and Python command overrides
+
+## Disabling memory
+
+To disable memory entirely, turn off MemPalace in **Settings > Memory**. Layer 1 (context injection) and Layer 2 (observation hooks) still operate using the built-in SQLite storage, but Layer 3 falls back to basic keyword search.
+
+To fully disable all memory layers, this requires a code change — memory is considered a core feature of Fury's agent orchestration.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,6 +92,7 @@
               "core/linear-integration",
               "core/azure-devops",
               "core/copilot",
+              "core/memory",
               "core/command-palette",
               "core/dev-containers"
             ]

--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -1,0 +1,614 @@
+# Fury Memory System — Architecture Design (v2)
+
+## How Fury Talks to Claude
+
+Fury uses the **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`) via a **Node.js sidecar process**. The flow is:
+
+```
+Fury UI (React) → Rust Backend (Tauri) → Node.js Sidecar → sdkQuery() → Claude API
+```
+
+The sidecar (`src-tauri/sidecar/src/index.ts`) calls `sdkQuery({ prompt, options })` which accepts:
+
+- `mcpServers` — register MCP servers (stdio, SSE, HTTP, or **in-process SDK servers**)
+- `hooks` — callbacks for `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd`, `Stop`, etc.
+- `systemPrompt` — string or `{ type: 'preset', preset: 'claude_code', append: '...' }`
+- `settingSources` — controls loading of `CLAUDE.md` and `.claude/` settings
+- `agents` — define subagents with their own tools, prompts, and MCP servers
+
+This gives us **three first-class integration points** for memory:
+
+1. **In-process MCP server** — runs inside the sidecar, no separate process needed
+2. **SDK hooks** — tap every tool call and session lifecycle event
+3. **System prompt injection** — prepend memory context before each session
+
+---
+
+## Three-Layer Architecture (Revised)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Node.js Sidecar Process                       │
+│                                                                  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  sdkQuery({ prompt, options: {                            │  │
+│  │    systemPrompt: { preset: 'claude_code', append: L1 },  │  │  ← Layer 1
+│  │    hooks: { PostToolUse: [L2], SessionEnd: [L2] },        │  │  ← Layer 2
+│  │    mcpServers: { 'fury-memory': inProcessMcpServer },     │  │  ← Layer 3
+│  │  }})                                                      │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                  │
+│  Layer 1: Context Injection (system prompt append)               │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  Before each query: read compressed memories from DB      │   │
+│  │  → format as markdown → append to systemPrompt            │   │
+│  │  Cost: ~2-4K tokens, fixed per session                    │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+│  Layer 2: Observation Hooks (PostToolUse + SessionEnd)           │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  PostToolUse hook: extract observations from tool results │   │
+│  │  SessionEnd hook: compress & persist to SQLite            │   │
+│  │  Cost: 0 tokens (runs in sidecar, not sent to API)        │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+│  Layer 3: On-Demand MCP Server (fury-memory)                    │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  In-process MCP server via createSdkMcpServer()          │   │
+│  │  Tools: search_memory, save_learning, get_context         │   │
+│  │  Backed by SQLite + FTS5                                  │   │
+│  │  Cost: ~200-500 tokens per query, only when Claude asks   │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+                               ▼
+                    ┌─────────────────────┐
+                    │  SQLite (fury.db)    │
+                    │  memory_observations │
+                    │  memory_snapshots    │
+                    │  + FTS5 index        │
+                    └─────────────────────┘
+```
+
+---
+
+## Layer 1: Context Injection via System Prompt
+
+### What It Does
+Before each `sdkQuery()` call, Fury reads compressed memory snapshots from SQLite and appends them to the system prompt. Claude starts every session already knowing the project context.
+
+### Implementation
+
+The sidecar already builds the `systemPrompt` option:
+
+```typescript
+// Current code (index.ts:101-107)
+if (systemPrompt) {
+  options.systemPrompt = {
+    type: "preset",
+    preset: "claude_code",
+    append: systemPrompt,
+  };
+}
+```
+
+We extend this to prepend memory context:
+
+```typescript
+// NEW: Build memory context before query
+const memoryContext = await memoryStore.getContextForWorkspace(id, cwd);
+
+const fullSystemPrompt = [
+  systemPrompt || '',
+  '',
+  '<!-- FURY:MEMORY:START -->',
+  memoryContext,  // Compressed learnings, decisions, patterns
+  '<!-- FURY:MEMORY:END -->',
+].filter(Boolean).join('\n');
+
+options.systemPrompt = {
+  type: "preset",
+  preset: "claude_code",
+  append: fullSystemPrompt,
+};
+```
+
+### What Gets Injected
+
+The memory context is a markdown block with three sections:
+
+```markdown
+## Project Memory
+
+### Key Decisions
+- Chose Zustand over Redux for state management (workspace: auth-refactor, 2026-04-01)
+- Using barrel exports for all component directories (repo-wide)
+
+### Patterns & Conventions
+- All IPC wrappers go in src/lib/tauri/*.ts
+- Tests use vi.waitFor() for async assertions after rAF
+- Mutex lock order: workspaces → repositories → container_states
+
+### Recent Context
+- Last session worked on: JWT token refresh logic in auth.rs
+- Open issue: flaky test in workspaceStore.test.ts line 247
+```
+
+### Scoping: Per-Workspace + Per-Repo + Global
+
+```typescript
+async getContextForWorkspace(workspaceId: string, cwd: string): Promise<string> {
+  const sections: string[] = [];
+
+  // Global preferences (user-level, all projects)
+  const global = await this.getSnapshots('global', null);
+  if (global.length) sections.push('### User Preferences\n' + format(global));
+
+  // Repo-level patterns (shared across branches)
+  const repoId = await this.getRepoIdForWorkspace(workspaceId);
+  const repo = await this.getSnapshots('repo', repoId);
+  if (repo.length) sections.push('### Project Patterns\n' + format(repo));
+
+  // Workspace-specific decisions & progress
+  const ws = await this.getSnapshots('workspace', workspaceId);
+  if (ws.length) sections.push('### Workspace Context\n' + format(ws));
+
+  return sections.join('\n\n');
+}
+```
+
+### Token Budget
+- Global preferences: ~200-500 tokens
+- Repo patterns: ~500-1K tokens
+- Workspace context: ~500-1K tokens
+- **Total: ~1.5-2.5K tokens per session** (fixed cost)
+
+---
+
+## Layer 2: Observation Extraction via SDK Hooks
+
+### What It Does
+Uses the SDK's `hooks` option to tap into tool calls and session lifecycle events. Extracts high-signal observations without sending any extra tokens to the API.
+
+### Implementation
+
+The SDK supports hooks directly in the `options` object:
+
+```typescript
+// In sidecar index.ts, add to the options object:
+options.hooks = {
+  PostToolUse: [{
+    hooks: [async (input: PostToolUseHookInput) => {
+      // Extract observations from tool results
+      const observation = extractObservation(input);
+      if (observation) {
+        await memoryStore.saveObservation(id, observation);
+      }
+      return {};  // Don't modify tool behavior
+    }],
+  }],
+
+  SessionEnd: [{
+    hooks: [async (input: SessionEndHookInput) => {
+      // Compress accumulated observations into snapshots
+      await memoryStore.compressObservations(id);
+      return {};
+    }],
+  }],
+
+  SessionStart: [{
+    hooks: [async (input: SessionStartHookInput) => {
+      // Log session start for timeline tracking
+      await memoryStore.recordSessionStart(id, input.session_id);
+      return {};
+    }],
+  }],
+};
+```
+
+### What Gets Extracted (PostToolUse)
+
+```typescript
+function extractObservation(input: PostToolUseHookInput): Observation | null {
+  const { tool_name, tool_input, tool_response } = input;
+
+  switch (tool_name) {
+    case 'Write':
+    case 'Edit':
+      // File was modified — record what and why
+      return {
+        type: 'file_change',
+        content: `Modified ${tool_input.file_path}`,
+        filePaths: [tool_input.file_path],
+        sourceTool: tool_name,
+      };
+
+    case 'Bash':
+      // Check for errors in output
+      const output = String(tool_response);
+      if (output.includes('error') || output.includes('Error') || output.includes('FAILED')) {
+        return {
+          type: 'error',
+          content: `Command failed: ${tool_input.command}\nOutput: ${output.slice(0, 500)}`,
+          sourceTool: 'Bash',
+        };
+      }
+      return null;  // Successful bash commands are low-signal
+
+    case 'Read':
+      // Don't record reads — too noisy
+      return null;
+
+    default:
+      return null;
+  }
+}
+```
+
+### Compression (SessionEnd)
+
+When a session ends, raw observations are compressed:
+
+```typescript
+async compressObservations(workspaceId: string): Promise<void> {
+  const observations = await this.getUncompressedObservations(workspaceId);
+  if (observations.length < 3) return;  // Not enough to compress
+
+  // Rule-based compression (zero API cost):
+  // 1. Deduplicate similar file_change observations
+  // 2. Keep only the most recent error per file
+  // 3. Extract decision-like patterns from assistant text
+  // 4. Merge into existing snapshots
+
+  const compressed = ruleBasedCompress(observations);
+  await this.saveSnapshot({
+    scope: 'workspace',
+    scopeId: workspaceId,
+    category: 'progress',
+    content: compressed,
+    observationIds: observations.map(o => o.id),
+  });
+}
+```
+
+### Token Cost: **Zero**
+Hooks run in the sidecar process, not in the API context. They observe tool calls that already happened without adding any tokens to the conversation.
+
+---
+
+## Layer 3: In-Process MCP Server
+
+### What It Does
+Exposes memory as tools that Claude can call on-demand during a session. Uses the SDK's `createSdkMcpServer()` to run the MCP server **in the same Node.js process** as the sidecar — no separate process, no stdio pipes.
+
+### Implementation
+
+```typescript
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const memoryServer = createSdkMcpServer({
+  name: "fury-memory",
+  version: "1.0.0",
+  tools: [
+    tool(
+      "search_memory",
+      "Search past observations and learnings from previous sessions. Use when you need context about past decisions, error patterns, or conventions in this project.",
+      {
+        query: z.string().describe("Natural language search query"),
+        scope: z.enum(["workspace", "repo", "global"]).default("workspace"),
+        limit: z.number().default(5),
+      },
+      async ({ query, scope, limit }) => {
+        const results = await memoryStore.search(query, scope, limit);
+        return {
+          content: [{
+            type: "text",
+            text: results.length
+              ? results.map(r => `[${r.category}] ${r.content}`).join('\n\n')
+              : "No matching memories found.",
+          }],
+        };
+      },
+      { annotations: { readOnlyHint: true, openWorldHint: false } }
+    ),
+
+    tool(
+      "save_learning",
+      "Save an important learning, decision, or pattern for future sessions. Use when you discover something important about this project that should persist.",
+      {
+        content: z.string().describe("What was learned"),
+        category: z.enum(["decision", "pattern", "preference", "error_fix"]),
+        scope: z.enum(["workspace", "repo", "global"]).default("workspace"),
+      },
+      async ({ content, category, scope }) => {
+        await memoryStore.saveLearning(content, category, scope);
+        return {
+          content: [{ type: "text", text: `Saved to ${scope} memory.` }],
+        };
+      },
+      { annotations: { readOnlyHint: false, openWorldHint: false } }
+    ),
+
+    tool(
+      "get_file_context",
+      "Get memory context related to specific files — what was changed, why, and any known issues.",
+      {
+        filePaths: z.array(z.string()).describe("File paths to look up"),
+      },
+      async ({ filePaths }) => {
+        const context = await memoryStore.getFileContext(filePaths);
+        return {
+          content: [{ type: "text", text: context || "No history for these files." }],
+        };
+      },
+      { annotations: { readOnlyHint: true, openWorldHint: false } }
+    ),
+  ],
+});
+```
+
+Then register it in the query options:
+
+```typescript
+options.mcpServers = {
+  ...existingMcpServers,
+  'fury-memory': memoryServer,  // In-process, no spawn overhead
+};
+```
+
+### Why In-Process MCP?
+
+The SDK supports `createSdkMcpServer()` which runs the MCP server in the same Node.js process. This means:
+
+- **Zero startup latency** — no process spawn, no stdio handshake
+- **Direct access to memoryStore** — shares the same SQLite connection
+- **No extra dependencies** — just Zod for schema validation (already in the SDK)
+- Claude discovers the tools automatically via MCP protocol
+
+### Token Cost
+- Tool definitions in context: ~500 tokens (fixed, loaded once)
+- Per search query: ~200-400 tokens (query + results)
+- Per save: ~100 tokens
+- **Only costs tokens when Claude chooses to use the tools**
+
+---
+
+## Database Schema
+
+### New Tables (add via migration)
+
+```sql
+-- Raw observations extracted from agent sessions via hooks
+CREATE TABLE IF NOT EXISTS memory_observations (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    repo_id TEXT NOT NULL REFERENCES repositories(id),
+    session_id TEXT,
+    observation_type TEXT NOT NULL,     -- 'decision', 'error', 'pattern', 'file_change', 'preference'
+    content TEXT NOT NULL,
+    compressed_content TEXT,            -- Rule-based summary
+    source_tool TEXT,                   -- 'Edit', 'Bash', 'Write', etc.
+    file_paths TEXT,                    -- JSON array
+    tokens_raw INTEGER,
+    tokens_compressed INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    accessed_at TEXT
+);
+
+CREATE INDEX idx_obs_workspace ON memory_observations(workspace_id);
+CREATE INDEX idx_obs_repo ON memory_observations(repo_id);
+CREATE INDEX idx_obs_type ON memory_observations(observation_type);
+
+-- FTS5 for fast text search
+CREATE VIRTUAL TABLE memory_observations_fts USING fts5(
+    content,
+    compressed_content,
+    content=memory_observations,
+    content_rowid=rowid
+);
+
+-- Compressed snapshots used by Layer 1 (context injection)
+CREATE TABLE IF NOT EXISTS memory_snapshots (
+    id TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,                -- 'workspace', 'repo', 'global'
+    scope_id TEXT,                      -- workspace_id, repo_id, or NULL
+    category TEXT NOT NULL,             -- 'decisions', 'patterns', 'progress', 'preferences'
+    content TEXT NOT NULL,              -- Markdown for system prompt
+    observation_ids TEXT NOT NULL,      -- JSON array of source IDs
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    supersedes TEXT                     -- Previous snapshot this replaces
+);
+
+CREATE INDEX idx_snap_scope ON memory_snapshots(scope, scope_id);
+```
+
+---
+
+## Communication: Rust ↔ Sidecar
+
+The sidecar already communicates with Rust via NDJSON on stdin/stdout. For memory, we extend the protocol:
+
+### New Sidecar Commands (Rust → Sidecar)
+
+```typescript
+// Add to protocol.ts
+| {
+    type: "memory_prepare";
+    id: string;                // workspace UUID
+    workspaceId: string;
+    repoId: string;
+  }
+| {
+    type: "memory_query";      // Direct DB query from Rust
+    id: string;
+    query: string;
+    scope: "workspace" | "repo" | "global";
+  }
+```
+
+### New Sidecar Events (Sidecar → Rust)
+
+```typescript
+// Memory events emitted to Rust for persistence
+| {
+    type: "memory_observation";
+    id: string;
+    observation: {
+      type: string;
+      content: string;
+      sourceTool: string;
+      filePaths: string[];
+    };
+  }
+| {
+    type: "memory_snapshot";
+    id: string;
+    snapshot: {
+      scope: string;
+      category: string;
+      content: string;
+    };
+  }
+```
+
+**Design choice**: The sidecar extracts observations (hooks run there), but the Rust backend owns SQLite persistence. The sidecar emits `memory_observation` events via stdout, and the Rust side's `handle_sidecar_line()` writes them to the database. This keeps the single-writer pattern for SQLite.
+
+---
+
+## Session Lifecycle (How It All Fits Together)
+
+```
+1. USER SENDS MESSAGE
+        │
+        ▼
+2. RUST: agent.rs receives SendMessageRequest
+   - Reads memory snapshots from SQLite
+   - Builds system prompt with memory context (Layer 1)
+   - Sends SidecarCommand::Query with enriched systemPrompt
+        │
+        ▼
+3. SIDECAR: handleQuery()
+   - Registers fury-memory MCP server (Layer 3)
+   - Registers PostToolUse + SessionEnd hooks (Layer 2)
+   - Calls sdkQuery({ prompt, options })
+        │
+        ▼
+4. DURING SESSION
+   ├── Claude works normally, using tools
+   ├── PostToolUse hooks silently extract observations → emit to Rust
+   ├── Claude MAY call search_memory or save_learning via MCP (Layer 3)
+   └── Rust backend persists observations to SQLite as they arrive
+        │
+        ▼
+5. SESSION ENDS
+   ├── SessionEnd hook fires → compress observations into snapshots
+   ├── Sidecar emits memory_snapshot events → Rust persists
+   └── Next session will read fresh snapshots in Layer 1
+```
+
+---
+
+## Token Budget (Complete Picture)
+
+```
+WITHOUT MEMORY:
+┌──────────────────────────────────────┐
+│ System prompt (claude_code):  ~10K   │
+│ CLAUDE.md (project):          ~2K    │
+│ User message:               ~0.5K   │
+│ Available for work:         ~187K   │
+│ Context window:              200K   │
+└──────────────────────────────────────┘
+
+WITH MEMORY:
+┌──────────────────────────────────────┐
+│ System prompt (claude_code):  ~10K   │
+│ CLAUDE.md (project):          ~2K    │
+│ Memory context (Layer 1):    ~2.5K   │  ← injected via append
+│ MCP tool defs (Layer 3):     ~0.5K   │  ← fury-memory tools
+│ User message:               ~0.5K   │
+│ Available for work:         ~184K   │
+│ Context window:              200K   │
+│                                      │
+│ On-demand MCP queries:  ~0.3K each   │  ← only when Claude asks
+│ Hook extraction:            0 tokens │  ← runs in sidecar
+│ Compression:                0 tokens │  ← rule-based, in sidecar
+└──────────────────────────────────────┘
+
+NET COST: ~3K tokens/session (~1.5% of context window)
+         + ~0.3K per on-demand memory query
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Layer 2 Hooks + SQLite Storage (1 week)
+**Start here because hooks are the data source for everything else.**
+
+Files to create:
+- `src-tauri/sidecar/src/memory/store.ts` — SQLite interface (read/write observations & snapshots)
+- `src-tauri/sidecar/src/memory/extractor.ts` — Observation extraction from PostToolUse hooks
+- `src-tauri/sidecar/src/memory/compressor.ts` — Rule-based compression logic
+
+Files to modify:
+- `src-tauri/sidecar/src/index.ts` — Add hooks to sdkQuery options
+- `src-tauri/sidecar/src/protocol.ts` — Add memory event types
+- `src-tauri/src/services/claude_process/sidecar.rs` — Handle memory events in handle_sidecar_line
+- `src-tauri/src/db/migrations/mod.rs` — Add memory tables
+
+### Phase 2: Layer 1 Context Injection (3-4 days)
+**Uses data from Phase 1 to enrich the system prompt.**
+
+Files to create:
+- `src-tauri/src/services/memory/mod.rs` — Rust-side memory service
+- `src-tauri/src/services/memory/context.rs` — Build memory context markdown
+- `src-tauri/src/commands/memory.rs` — Tauri commands for memory management UI
+
+Files to modify:
+- `src-tauri/src/commands/agent.rs` — Read snapshots and inject into system_prompt before query
+- `src-tauri/sidecar/src/protocol.ts` — Accept memory context in QueryCommand
+
+### Phase 3: Layer 3 MCP Server (1 week)
+**Gives Claude on-demand access to the full memory store.**
+
+Files to create:
+- `src-tauri/sidecar/src/memory/mcp.ts` — In-process MCP server with search/save tools
+
+Files to modify:
+- `src-tauri/sidecar/src/index.ts` — Register MCP server in query options
+- `src-tauri/sidecar/src/memory/store.ts` — Add search/save methods
+
+### Phase 4: UI + Settings (3-4 days)
+
+- Memory panel in Settings (enable/disable, choose compression mode)
+- Memory viewer component (browse/edit/delete memories)
+- Memory indicator in workspace header
+- Per-workspace vs global memory toggle
+
+---
+
+## Key Design Decisions
+
+### Q: Why hooks instead of parsing the NDJSON stream in Rust?
+The SDK hooks give us structured, typed data (`tool_name`, `tool_input`, `tool_response`) directly. Parsing NDJSON in Rust means reverse-engineering the stream format and dealing with partial messages. Hooks are the supported API for this.
+
+### Q: SQLite in sidecar or Rust?
+**Rust owns SQLite** (single writer). The sidecar emits events, Rust persists them. This avoids two processes competing for the same database and matches the existing pattern (chat messages are already persisted by Rust).
+
+### Q: Why not use the Anthropic Memory Tool (`memory_20250818`)?
+That tool is for the raw Messages API. The Agent SDK has its own MCP-based approach which is more powerful — you get typed tools, in-process execution, and full control over the storage backend. The MCP server approach also means the tools show up in Claude's available tools automatically.
+
+### Q: What about Auto Dream / MEMORY.md?
+The SDK reads `MEMORY.md` when `settingSources` includes `'project'` (which Fury already enables). Auto Dream consolidation happens between sessions. Our memory system **complements** this — Auto Dream handles Claude's self-written notes, our system handles structured observations that Claude didn't explicitly choose to write down.
+
+### Q: Embeddings or FTS5?
+Start with FTS5. It's already in SQLite, zero extra dependencies, handles keyword-based retrieval well. The `search_memory` MCP tool can upgrade to embeddings later if FTS5 proves insufficient — the interface stays the same, only the backend changes.
+
+### Q: How do we prevent memory from growing unbounded?
+Three mechanisms:
+1. **Snapshot supersession** — new snapshots replace old ones (tracked via `supersedes` column)
+2. **Observation TTL** — observations older than 30 days without access get pruned
+3. **Token budget cap** — Layer 1 context is capped at ~3K tokens; if snapshots exceed this, oldest are dropped

--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -1,5 +1,9 @@
 # Fury Memory System — Architecture Design (v2)
 
+> **Note:** This is an internal design document. For user-facing documentation, see [Memory](core/memory.mdx).
+>
+> **Update (v2.1):** Layer 3 now supports [MemPalace](https://github.com/milla-jovovich/mempalace) as an external MCP server for semantic search via ChromaDB. When MemPalace is available, it replaces the in-process MCP server with 19 tools including vector search, knowledge graph queries, and palace navigation. The in-process server remains as a fallback. MemPalace is enabled by default — see Settings > Memory.
+
 ## How Fury Talks to Claude
 
 Fury uses the **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`) via a **Node.js sidecar process**. The flow is:

--- a/src-tauri/sidecar/package.json
+++ b/src-tauri/sidecar/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "latest",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.0",

--- a/src-tauri/sidecar/src/index.ts
+++ b/src-tauri/sidecar/src/index.ts
@@ -36,6 +36,8 @@ async function handleQuery(cmd: QueryCommand): Promise<void> {
     disableThinking,
     repoId,
     memoryEnabled,
+    mempalacePythonCmd,
+    mempalacePalacePath,
   } = cmd;
 
   // Build env: inherit current process.env and overlay workspace-specific vars
@@ -146,6 +148,23 @@ async function handleQuery(cmd: QueryCommand): Promise<void> {
             try {
               if (memoryStore) {
                 memoryStore.compressAndEmit();
+                // Sync observations to MemPalace if configured
+                if (mempalacePythonCmd && mempalacePalacePath) {
+                  const allObs = memoryStore.getAll();
+                  if (allObs.length > 0) {
+                    emit({
+                      id,
+                      type: "mempalace_sync",
+                      repoName: repoId || "default",
+                      observations: allObs.map(obs => ({
+                        content: obs.content,
+                        category: obs.observationType,
+                        filePaths: obs.filePaths,
+                        sourceTool: obs.sourceTool,
+                      })),
+                    });
+                  }
+                }
               }
             } catch {
               // Never let memory errors break the agent
@@ -155,15 +174,28 @@ async function handleQuery(cmd: QueryCommand): Promise<void> {
         }],
       };
 
-      // Layer 3: In-process MCP server for on-demand memory access
-      try {
-        const memoryMcpServer = createMemoryMcpServer(memoryStore);
+      // Layer 3: MCP server for on-demand memory access
+      if (mempalacePythonCmd && mempalacePalacePath) {
+        // External MemPalace MCP server (semantic search via ChromaDB)
         options.mcpServers = {
           ...(options.mcpServers as Record<string, unknown> || {}),
-          "fury-memory": memoryMcpServer,
+          "mempalace": {
+            type: "stdio",
+            command: mempalacePythonCmd,
+            args: ["-m", "mempalace.mcp_server", "--palace", mempalacePalacePath],
+          },
         };
-      } catch {
-        // MCP server creation failed — continue without it
+      } else {
+        // Fallback: in-process MCP server (keyword search)
+        try {
+          const memoryMcpServer = createMemoryMcpServer(memoryStore);
+          options.mcpServers = {
+            ...(options.mcpServers as Record<string, unknown> || {}),
+            "fury-memory": memoryMcpServer,
+          };
+        } catch {
+          // MCP server creation failed — continue without it
+        }
       }
     }
 

--- a/src-tauri/sidecar/src/index.ts
+++ b/src-tauri/sidecar/src/index.ts
@@ -6,6 +6,7 @@ import type {
   PermissionResponseCommand,
   InterruptCommand,
 } from "./protocol.js";
+import { MemoryStore, extractObservation, createMemoryMcpServer } from "./memory/index.js";
 
 // Track active queries and pending permissions per workspace
 const activeQueries = new Map<string, { abort: () => void }>();
@@ -33,6 +34,8 @@ async function handleQuery(cmd: QueryCommand): Promise<void> {
     envVars,
     additionalDirs,
     disableThinking,
+    repoId,
+    memoryEnabled,
   } = cmd;
 
   // Build env: inherit current process.env and overlay workspace-specific vars
@@ -109,6 +112,60 @@ async function handleQuery(cmd: QueryCommand): Promise<void> {
     if (disallowedTools) options.disallowedTools = disallowedTools;
     if (additionalDirs) options.additionalDirectories = additionalDirs;
     if (disableThinking) options.thinking = { type: "disabled" };
+
+    // --- Memory System (Layers 2 & 3) ---
+    let memoryStore: MemoryStore | null = null;
+    if (memoryEnabled !== false) {
+      memoryStore = new MemoryStore(id, repoId || "", emit);
+
+      // Layer 2: Hook-based observation extraction
+      options.hooks = {
+        PostToolUse: [{
+          hooks: [async (input: Record<string, unknown>) => {
+            try {
+              const obs = extractObservation(input as Parameters<typeof extractObservation>[0]);
+              if (obs && memoryStore) {
+                memoryStore.addObservation(obs);
+              }
+            } catch {
+              // Never let memory errors break the agent
+            }
+            return {};
+          }],
+        }],
+        SessionStart: [{
+          hooks: [async (input: Record<string, unknown>) => {
+            if (memoryStore && input.session_id) {
+              memoryStore.setSessionId(input.session_id as string);
+            }
+            return {};
+          }],
+        }],
+        SessionEnd: [{
+          hooks: [async () => {
+            try {
+              if (memoryStore) {
+                memoryStore.compressAndEmit();
+              }
+            } catch {
+              // Never let memory errors break the agent
+            }
+            return {};
+          }],
+        }],
+      };
+
+      // Layer 3: In-process MCP server for on-demand memory access
+      try {
+        const memoryMcpServer = createMemoryMcpServer(memoryStore);
+        options.mcpServers = {
+          ...(options.mcpServers as Record<string, unknown> || {}),
+          "fury-memory": memoryMcpServer,
+        };
+      } catch {
+        // MCP server creation failed — continue without it
+      }
+    }
 
     const q = sdkQuery({
       prompt,

--- a/src-tauri/sidecar/src/memory/compressor.ts
+++ b/src-tauri/sidecar/src/memory/compressor.ts
@@ -1,0 +1,202 @@
+/**
+ * Layer 2: Rule-Based Compressor
+ *
+ * Compresses raw observations into concise snapshots for Layer 1 context injection.
+ * Zero API token cost — runs entirely in the sidecar process.
+ */
+
+import type { Observation } from "./extractor.js";
+
+export interface CompressedSnapshot {
+  scope: string;
+  scopeId: string | null;
+  category: string;
+  content: string;
+  observationIds: string[];
+}
+
+interface StoredObservation extends Observation {
+  id: string;
+  createdAt: string;
+}
+
+/**
+ * Compress a set of observations into category-based snapshots.
+ * Deduplicates, summarizes, and caps output to a token budget.
+ */
+export function compressObservations(
+  observations: StoredObservation[],
+  scope: string,
+  scopeId: string | null,
+  maxItemsPerCategory: number = 10,
+): CompressedSnapshot[] {
+  const snapshots: CompressedSnapshot[] = [];
+
+  // Group by type
+  const byType = new Map<string, StoredObservation[]>();
+  for (const obs of observations) {
+    const group = byType.get(obs.observationType) || [];
+    group.push(obs);
+    byType.set(obs.observationType, group);
+  }
+
+  // Decisions
+  const decisions = byType.get("decision") || [];
+  if (decisions.length > 0) {
+    const deduped = deduplicateByContent(decisions, maxItemsPerCategory);
+    snapshots.push({
+      scope,
+      scopeId,
+      category: "decisions",
+      content: deduped.map((d) => `- ${d.content}`).join("\n"),
+      observationIds: deduped.map((d) => d.id),
+    });
+  }
+
+  // Patterns & conventions
+  const patterns = byType.get("pattern") || [];
+  if (patterns.length > 0) {
+    const deduped = deduplicateByContent(patterns, maxItemsPerCategory);
+    snapshots.push({
+      scope,
+      scopeId,
+      category: "patterns",
+      content: deduped.map((p) => `- ${p.content}`).join("\n"),
+      observationIds: deduped.map((p) => p.id),
+    });
+  }
+
+  // Recent errors (keep only most recent per file)
+  const errors = byType.get("error") || [];
+  if (errors.length > 0) {
+    const recentErrors = deduplicateErrorsByFile(errors, 5);
+    snapshots.push({
+      scope,
+      scopeId,
+      category: "errors",
+      content: recentErrors.map((e) => `- ${e.content}`).join("\n"),
+      observationIds: recentErrors.map((e) => e.id),
+    });
+  }
+
+  // File changes — summarize as "recently modified files"
+  const fileChanges = byType.get("file_change") || [];
+  if (fileChanges.length > 0) {
+    const recentFiles = summarizeFileChanges(fileChanges, maxItemsPerCategory);
+    snapshots.push({
+      scope,
+      scopeId,
+      category: "progress",
+      content: recentFiles,
+      observationIds: fileChanges.slice(0, maxItemsPerCategory).map((f) => f.id),
+    });
+  }
+
+  // Preferences
+  const preferences = byType.get("preference") || [];
+  if (preferences.length > 0) {
+    const deduped = deduplicateByContent(preferences, maxItemsPerCategory);
+    snapshots.push({
+      scope,
+      scopeId,
+      category: "preferences",
+      content: deduped.map((p) => `- ${p.content}`).join("\n"),
+      observationIds: deduped.map((p) => p.id),
+    });
+  }
+
+  return snapshots;
+}
+
+/**
+ * Deduplicate observations by content similarity.
+ * Uses simple string overlap to detect near-duplicates.
+ */
+function deduplicateByContent(
+  observations: StoredObservation[],
+  maxItems: number,
+): StoredObservation[] {
+  // Sort by most recent first
+  const sorted = [...observations].sort(
+    (a, b) => b.createdAt.localeCompare(a.createdAt),
+  );
+
+  const kept: StoredObservation[] = [];
+  for (const obs of sorted) {
+    if (kept.length >= maxItems) break;
+
+    // Check if we already have something very similar
+    const isDuplicate = kept.some(
+      (existing) => contentSimilarity(existing.content, obs.content) > 0.7,
+    );
+
+    if (!isDuplicate) {
+      kept.push(obs);
+    }
+  }
+
+  return kept;
+}
+
+/**
+ * Deduplicate errors — keep only the most recent error per file path.
+ */
+function deduplicateErrorsByFile(
+  errors: StoredObservation[],
+  maxItems: number,
+): StoredObservation[] {
+  const byFile = new Map<string, StoredObservation>();
+
+  // Sort by most recent first, then take first per file
+  const sorted = [...errors].sort(
+    (a, b) => b.createdAt.localeCompare(a.createdAt),
+  );
+
+  for (const err of sorted) {
+    const key = err.filePaths.length > 0 ? err.filePaths[0] : err.content.slice(0, 50);
+    if (!byFile.has(key)) {
+      byFile.set(key, err);
+    }
+  }
+
+  return [...byFile.values()].slice(0, maxItems);
+}
+
+/**
+ * Summarize file changes into a concise list.
+ */
+function summarizeFileChanges(
+  changes: StoredObservation[],
+  maxItems: number,
+): string {
+  // Count modifications per file
+  const fileCounts = new Map<string, number>();
+  for (const change of changes) {
+    for (const fp of change.filePaths) {
+      fileCounts.set(fp, (fileCounts.get(fp) || 0) + 1);
+    }
+  }
+
+  // Sort by most modified
+  const sorted = [...fileCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxItems);
+
+  return sorted.map(([file, count]) => `- ${file} (${count} changes)`).join("\n");
+}
+
+/**
+ * Simple content similarity using word overlap (Jaccard index).
+ */
+function contentSimilarity(a: string, b: string): number {
+  const wordsA = new Set(a.toLowerCase().split(/\s+/));
+  const wordsB = new Set(b.toLowerCase().split(/\s+/));
+
+  let intersection = 0;
+  for (const word of wordsA) {
+    if (wordsB.has(word)) intersection++;
+  }
+
+  const union = wordsA.size + wordsB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}

--- a/src-tauri/sidecar/src/memory/extractor.ts
+++ b/src-tauri/sidecar/src/memory/extractor.ts
@@ -1,0 +1,191 @@
+/**
+ * Layer 2: Observation Extractor
+ *
+ * Extracts high-signal observations from PostToolUse hook events.
+ * Runs in the sidecar process — zero API token cost.
+ */
+
+export interface Observation {
+  observationType: string;
+  content: string;
+  sourceTool: string | null;
+  filePaths: string[];
+}
+
+interface PostToolUseInput {
+  hook_event_name: "PostToolUse";
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_response: unknown;
+  session_id: string;
+  cwd: string;
+}
+
+/**
+ * Extract an observation from a PostToolUse hook event.
+ * Returns null for low-signal events (reads, successful simple commands).
+ */
+export function extractObservation(input: PostToolUseInput): Observation | null {
+  const { tool_name, tool_input, tool_response } = input;
+
+  switch (tool_name) {
+    case "Write":
+    case "Edit": {
+      const filePath = (tool_input.file_path as string) || (tool_input.path as string) || "";
+      if (!filePath) return null;
+
+      const oldStr = tool_input.old_string as string | undefined;
+      const newStr = tool_input.new_string as string | undefined;
+      let description = `Modified ${relativePath(filePath, input.cwd)}`;
+      if (oldStr && newStr) {
+        description += ` (replaced ${truncate(oldStr, 50)} → ${truncate(newStr, 50)})`;
+      }
+
+      return {
+        observationType: "file_change",
+        content: description,
+        sourceTool: tool_name,
+        filePaths: [filePath],
+      };
+    }
+
+    case "Bash": {
+      const command = (tool_input.command as string) || "";
+      const output = stringifyResponse(tool_response);
+
+      // Check for errors
+      const hasError =
+        output.includes("error") ||
+        output.includes("Error") ||
+        output.includes("FAILED") ||
+        output.includes("ENOENT") ||
+        output.includes("Permission denied");
+
+      if (hasError) {
+        return {
+          observationType: "error",
+          content: `Command failed: ${truncate(command, 100)}\nOutput: ${truncate(output, 300)}`,
+          sourceTool: "Bash",
+          filePaths: extractFilePathsFromText(command),
+        };
+      }
+
+      // Capture significant commands (installs, builds, test runs)
+      if (isSignificantCommand(command)) {
+        return {
+          observationType: "pattern",
+          content: `Ran: ${truncate(command, 200)}`,
+          sourceTool: "Bash",
+          filePaths: [],
+        };
+      }
+
+      return null; // Skip ordinary successful commands
+    }
+
+    case "Read":
+    case "Glob":
+    case "Grep":
+      // Read-only tools — too noisy to record
+      return null;
+
+    default:
+      // MCP tools or unknown tools — record if they seem significant
+      if (tool_name.startsWith("mcp__")) {
+        return {
+          observationType: "pattern",
+          content: `Used MCP tool: ${tool_name}(${truncate(JSON.stringify(tool_input), 150)})`,
+          sourceTool: tool_name,
+          filePaths: [],
+        };
+      }
+      return null;
+  }
+}
+
+/**
+ * Extract observations from assistant text (decisions, patterns).
+ * Called on assistant messages to detect when Claude explains its reasoning.
+ */
+export function extractFromAssistantText(text: string): Observation | null {
+  // Look for decision language
+  const decisionPatterns = [
+    /\b(?:decided|chose|choosing|picked|selected|going with|opted for)\b/i,
+    /\b(?:because|reason is|rationale|trade-?off)\b/i,
+  ];
+
+  const patternIndicators = [
+    /\b(?:convention|pattern|always|never|standard|best practice)\b/i,
+    /\b(?:this codebase|in this project|we use|you use)\b/i,
+  ];
+
+  const isDecision = decisionPatterns.some((p) => p.test(text));
+  const isPattern = patternIndicators.some((p) => p.test(text));
+
+  if (isDecision && text.length > 50 && text.length < 500) {
+    return {
+      observationType: "decision",
+      content: truncate(text, 300),
+      sourceTool: null,
+      filePaths: extractFilePathsFromText(text),
+    };
+  }
+
+  if (isPattern && text.length > 30 && text.length < 300) {
+    return {
+      observationType: "pattern",
+      content: truncate(text, 200),
+      sourceTool: null,
+      filePaths: extractFilePathsFromText(text),
+    };
+  }
+
+  return null;
+}
+
+// --- Helpers ---
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+function relativePath(fullPath: string, cwd: string): string {
+  if (fullPath.startsWith(cwd)) {
+    return fullPath.slice(cwd.length).replace(/^[/\\]/, "");
+  }
+  return fullPath;
+}
+
+function stringifyResponse(response: unknown): string {
+  if (typeof response === "string") return response;
+  if (response == null) return "";
+  try {
+    return JSON.stringify(response);
+  } catch {
+    return String(response);
+  }
+}
+
+function isSignificantCommand(command: string): boolean {
+  const significant = [
+    /\bnpm\s+(install|run|test|build)/,
+    /\bcargo\s+(build|test|check|run)/,
+    /\bgit\s+(commit|merge|rebase|checkout)/,
+    /\bpip\s+install/,
+    /\bdocker\b/,
+    /\bmake\b/,
+  ];
+  return significant.some((p) => p.test(command));
+}
+
+function extractFilePathsFromText(text: string): string[] {
+  // Match common file path patterns
+  const pathRegex = /(?:^|\s)((?:\.\/|\/|src\/|lib\/)\S+\.\w{1,10})/g;
+  const paths: string[] = [];
+  let match;
+  while ((match = pathRegex.exec(text)) !== null) {
+    paths.push(match[1].trim());
+  }
+  return [...new Set(paths)].slice(0, 10); // Dedupe, limit to 10
+}

--- a/src-tauri/sidecar/src/memory/index.ts
+++ b/src-tauri/sidecar/src/memory/index.ts
@@ -1,0 +1,4 @@
+export { extractObservation, extractFromAssistantText } from "./extractor.js";
+export { compressObservations } from "./compressor.js";
+export { MemoryStore } from "./store.js";
+export { createMemoryMcpServer } from "./mcp-server.js";

--- a/src-tauri/sidecar/src/memory/mcp-server.ts
+++ b/src-tauri/sidecar/src/memory/mcp-server.ts
@@ -1,0 +1,117 @@
+/**
+ * Layer 3: In-Process MCP Server for Memory
+ *
+ * Provides on-demand memory tools that Claude can call during a session.
+ * Runs in the same process as the sidecar — zero startup latency.
+ */
+
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { MemoryStore } from "./store.js";
+
+/**
+ * Create the fury-memory MCP server with search and save tools.
+ */
+export function createMemoryMcpServer(store: MemoryStore) {
+  return createSdkMcpServer({
+    name: "fury-memory",
+    version: "1.0.0",
+    tools: [
+      tool(
+        "search_memory",
+        "Search past observations and learnings from previous sessions in this project. Use when you need context about past decisions, error patterns, conventions, or what was previously tried. Returns compressed observations matching your query.",
+        {
+          query: z.string().describe("Natural language search query"),
+          scope: z
+            .enum(["workspace", "repo", "global"])
+            .default("workspace")
+            .describe("Scope to search: workspace (current branch), repo (all branches), or global (all projects)"),
+          limit: z.number().default(5).describe("Max results to return"),
+        },
+        async ({ query, scope, limit }) => {
+          const results = await store.search(query, scope, limit);
+          if (results.length === 0) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "No matching memories found.",
+                },
+              ],
+            };
+          }
+          const formatted = results
+            .map(
+              (r) =>
+                `[${r.observationType}] ${r.content}${r.filePaths.length > 0 ? ` (files: ${r.filePaths.join(", ")})` : ""}`,
+            )
+            .join("\n\n");
+          return {
+            content: [{ type: "text" as const, text: formatted }],
+          };
+        },
+        { annotations: { readOnlyHint: true, openWorldHint: false } },
+      ),
+
+      tool(
+        "save_learning",
+        "Save an important learning, decision, or pattern for future sessions. Use when you discover something important about this project that should be remembered across sessions — architectural decisions, coding patterns, user preferences, or error fixes.",
+        {
+          content: z.string().describe("What was learned — be specific and concise"),
+          category: z
+            .enum(["decision", "pattern", "preference", "error_fix"])
+            .describe("Type of learning"),
+          scope: z
+            .enum(["workspace", "repo", "global"])
+            .default("workspace")
+            .describe("Scope: workspace (this branch only), repo (all branches), or global (all projects)"),
+        },
+        async ({ content, category, scope }) => {
+          await store.saveLearning(content, category, scope);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Saved to ${scope} memory: [${category}] ${content}`,
+              },
+            ],
+          };
+        },
+        {
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            openWorldHint: false,
+          },
+        },
+      ),
+
+      tool(
+        "get_file_context",
+        "Get memory context related to specific files — what was changed, why, and any known issues. Use when you are about to modify a file and want to know its history.",
+        {
+          file_paths: z
+            .array(z.string())
+            .describe("File paths to look up history for"),
+        },
+        async ({ file_paths }) => {
+          const context = await store.getFileContext(file_paths);
+          if (!context) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "No history found for these files.",
+                },
+              ],
+            };
+          }
+          return {
+            content: [{ type: "text" as const, text: context }],
+          };
+        },
+        { annotations: { readOnlyHint: true, openWorldHint: false } },
+      ),
+    ],
+  });
+}

--- a/src-tauri/sidecar/src/memory/store.ts
+++ b/src-tauri/sidecar/src/memory/store.ts
@@ -1,0 +1,197 @@
+/**
+ * Memory Store
+ *
+ * Manages in-memory observation buffer and emits events to the Rust backend
+ * for SQLite persistence. The sidecar is stateless across restarts —
+ * all durable storage goes through Rust via NDJSON events.
+ */
+
+import type { Observation } from "./extractor.js";
+import { compressObservations, type CompressedSnapshot } from "./compressor.js";
+
+export interface StoredObservation extends Observation {
+  id: string;
+  createdAt: string;
+  sessionId: string | null;
+}
+
+export interface SearchResult {
+  observationType: string;
+  content: string;
+  filePaths: string[];
+  createdAt: string;
+}
+
+type EmitFn = (event: Record<string, unknown>) => void;
+
+/**
+ * In-memory observation buffer that emits to Rust for persistence.
+ * Each workspace gets its own store instance.
+ */
+export class MemoryStore {
+  private observations: StoredObservation[] = [];
+  private workspaceId: string;
+  private repoId: string;
+  private sessionId: string | null = null;
+  private emit: EmitFn;
+
+  constructor(workspaceId: string, repoId: string, emit: EmitFn) {
+    this.workspaceId = workspaceId;
+    this.repoId = repoId;
+    this.emit = emit;
+  }
+
+  setSessionId(sessionId: string): void {
+    this.sessionId = sessionId;
+  }
+
+  /**
+   * Add an observation (from PostToolUse hook).
+   * Immediately emits to Rust for SQLite persistence.
+   */
+  addObservation(obs: Observation): void {
+    const stored: StoredObservation = {
+      ...obs,
+      id: generateId(),
+      createdAt: new Date().toISOString(),
+      sessionId: this.sessionId,
+    };
+    this.observations.push(stored);
+
+    // Emit to Rust for persistence
+    this.emit({
+      id: this.workspaceId,
+      type: "memory_observation",
+      repo_id: this.repoId,
+      observation: {
+        observationType: obs.observationType,
+        content: obs.content,
+        sourceTool: obs.sourceTool,
+        filePaths: obs.filePaths,
+        sessionId: this.sessionId,
+      },
+    });
+  }
+
+  /**
+   * Search observations in the local buffer.
+   * For cross-session search, the MCP tool should query Rust via a command,
+   * but for in-session search, the buffer is sufficient.
+   */
+  async search(
+    query: string,
+    _scope: string,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    const lowerQuery = query.toLowerCase();
+    const words = lowerQuery.split(/\s+/).filter(Boolean);
+
+    return this.observations
+      .filter((obs) => {
+        const text = obs.content.toLowerCase();
+        return words.some((w) => text.includes(w));
+      })
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit)
+      .map((obs) => ({
+        observationType: obs.observationType,
+        content: obs.content,
+        filePaths: obs.filePaths,
+        createdAt: obs.createdAt,
+      }));
+  }
+
+  /**
+   * Save a learning (from the MCP save_learning tool).
+   * Emits as a snapshot event to Rust.
+   */
+  async saveLearning(
+    content: string,
+    category: string,
+    scope: string,
+  ): Promise<void> {
+    const scopeId =
+      scope === "global"
+        ? null
+        : scope === "repo"
+          ? this.repoId
+          : this.workspaceId;
+
+    this.emit({
+      id: this.workspaceId,
+      type: "memory_snapshot",
+      snapshot: {
+        id: generateId(),
+        scope,
+        scopeId,
+        category,
+        content: `- ${content}`,
+        observationIds: [],
+        createdAt: new Date().toISOString(),
+        supersedes: null,
+      },
+    });
+  }
+
+  /**
+   * Get file-related observations for context.
+   */
+  async getFileContext(filePaths: string[]): Promise<string | null> {
+    const relevant = this.observations.filter((obs) =>
+      obs.filePaths.some((fp) => filePaths.some((target) => fp.includes(target) || target.includes(fp))),
+    );
+
+    if (relevant.length === 0) return null;
+
+    return relevant
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, 10)
+      .map(
+        (obs) =>
+          `[${obs.observationType}] ${obs.content} (${new Date(obs.createdAt).toLocaleDateString()})`,
+      )
+      .join("\n");
+  }
+
+  /**
+   * Compress observations into snapshots (called on SessionEnd).
+   * Emits compressed snapshots to Rust for persistence.
+   */
+  compressAndEmit(): void {
+    if (this.observations.length < 3) return; // Not enough to compress
+
+    const snapshots = compressObservations(
+      this.observations,
+      "workspace",
+      this.workspaceId,
+    );
+
+    for (const snapshot of snapshots) {
+      this.emit({
+        id: this.workspaceId,
+        type: "memory_snapshot",
+        snapshot: {
+          id: generateId(),
+          scope: snapshot.scope,
+          scopeId: snapshot.scopeId,
+          category: snapshot.category,
+          content: snapshot.content,
+          observationIds: snapshot.observationIds,
+          createdAt: new Date().toISOString(),
+          supersedes: null,
+        },
+      });
+    }
+  }
+
+  /**
+   * Get observation count (for diagnostics).
+   */
+  get observationCount(): number {
+    return this.observations.length;
+  }
+}
+
+function generateId(): string {
+  return `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src-tauri/sidecar/src/memory/store.ts
+++ b/src-tauri/sidecar/src/memory/store.ts
@@ -185,6 +185,13 @@ export class MemoryStore {
   }
 
   /**
+   * Get all observations (for MemPalace sync).
+   */
+  getAll(): StoredObservation[] {
+    return this.observations;
+  }
+
+  /**
    * Get observation count (for diagnostics).
    */
   get observationCount(): number {

--- a/src-tauri/sidecar/src/protocol.ts
+++ b/src-tauri/sidecar/src/protocol.ts
@@ -16,6 +16,8 @@ export type SidecarCommand =
       disableThinking?: boolean;
       repoId?: string; // for memory scoping
       memoryEnabled?: boolean; // enable memory system
+      mempalacePythonCmd?: string; // python command for MemPalace MCP server
+      mempalacePalacePath?: string; // palace directory path
     }
   | { type: "permission_response"; id: string; approved: boolean; updatedPermissions?: unknown[]; decisionClassification?: string; updatedInput?: Record<string, unknown> }
   | { type: "interrupt"; id: string }

--- a/src-tauri/sidecar/src/protocol.ts
+++ b/src-tauri/sidecar/src/protocol.ts
@@ -14,6 +14,8 @@ export type SidecarCommand =
       envVars?: Record<string, string>;
       additionalDirs?: string[];
       disableThinking?: boolean;
+      repoId?: string; // for memory scoping
+      memoryEnabled?: boolean; // enable memory system
     }
   | { type: "permission_response"; id: string; approved: boolean; updatedPermissions?: unknown[]; decisionClassification?: string; updatedInput?: Record<string, unknown> }
   | { type: "interrupt"; id: string }

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -431,31 +431,28 @@ pub async fn send_message(
         request.repo_id.map(|id| id.to_string())
     };
 
-    let system_prompt = {
+    let base_prompt = {
         let settings = state.settings.read().unwrap();
-        let base_prompt = settings.system_prompt_additions.clone();
+        settings.system_prompt_additions.clone()
+    };
 
-        // Build memory context from DB snapshots
-        let memory_context = {
-            let ws_id = context_id.to_string();
+    // Build memory context from DB snapshots (via spawn_blocking to avoid blocking executor)
+    let memory_context = if let Some(rid) = repo_id_for_memory.as_deref() {
+        let ws_id = context_id.to_string();
+        let rid = rid.to_string();
+        state
+            .with_db(move |db| Ok(db.build_memory_context(&ws_id, &rid).ok().flatten()))
+            .await
+            .unwrap_or(None)
+    } else {
+        None
+    };
 
-            if let Some(rid) = repo_id_for_memory.as_deref() {
-                let db_guard = state.db.lock().unwrap_or_else(|e| e.into_inner());
-                db_guard.as_ref().and_then(|db| {
-                    db.build_memory_context(&ws_id, rid).ok().flatten()
-                })
-            } else {
-                None
-            }
-        };
-
-        // Combine: base prompt + memory context
-        match (base_prompt, memory_context) {
-            (Some(base), Some(mem)) => Some(format!("{}\n\n{}", base, mem)),
-            (Some(base), None) => Some(base),
-            (None, Some(mem)) => Some(mem),
-            (None, None) => None,
-        }
+    let system_prompt = match (base_prompt, memory_context) {
+        (Some(base), Some(mem)) => Some(format!("{}\n\n{}", base, mem)),
+        (Some(base), None) => Some(base),
+        (None, Some(mem)) => Some(mem),
+        (None, None) => None,
     };
 
     let (disable_thinking, disable_plan_mode) = extract_toggle_flags(&request);
@@ -511,7 +508,7 @@ pub async fn send_message(
         // race conditions where concurrent callers find the handle missing.
         let permission_mode = resolve_permission_mode(disable_plan_mode);
 
-        let cmd = claude_process::SidecarCommand::Query {
+        let mut cmd = claude_process::SidecarCommand::Query {
             id: context_id.to_string(),
             prompt: request.message.clone(),
             cwd: working_dir.to_string_lossy().to_string(),
@@ -524,7 +521,25 @@ pub async fn send_message(
             disable_thinking: Some(disable_thinking),
             repo_id: repo_id_for_memory.clone(),
             memory_enabled: Some(true),
+            mempalace_python_cmd: None,
+            mempalace_palace_path: None,
         };
+
+        // If MemPalace is enabled, detect and populate config
+        {
+            let mp_settings = state.settings.read().unwrap().mempalace.clone();
+            if mp_settings.enabled {
+                if let Some(py_cmd) = crate::services::mempalace::detect_python(mp_settings.python_command.as_deref()).await {
+                    if crate::services::mempalace::detect_mempalace(&py_cmd).await.is_some() {
+                        let palace_path = crate::services::mempalace::resolve_palace_path(mp_settings.palace_path.as_deref());
+                        if let claude_process::SidecarCommand::Query { ref mut mempalace_python_cmd, ref mut mempalace_palace_path, .. } = cmd {
+                            *mempalace_python_cmd = Some(py_cmd);
+                            *mempalace_palace_path = Some(palace_path);
+                        }
+                    }
+                }
+            }
+        }
 
         let mut guard = state.agent_sidecar.lock().await;
         if guard.is_none() {
@@ -804,10 +819,27 @@ pub async fn send_followup_message(
         (ws.worktree_path.to_string_lossy().to_string(), env, ws.repo_id.to_string())
     };
 
-    // Read system prompt from settings
-    let system_prompt = {
+    // Read system prompt from settings + memory context (Layer 1)
+    let base_prompt = {
         let settings = state.settings.read().unwrap();
         settings.system_prompt_additions.clone()
+    };
+
+    // Build memory context from DB snapshots (via spawn_blocking)
+    let memory_context = {
+        let rid = repo_id_for_memory.clone();
+        let ws_id = id.to_string();
+        state
+            .with_db(move |db| Ok(db.build_memory_context(&ws_id, &rid).ok().flatten()))
+            .await
+            .unwrap_or(None)
+    };
+
+    let system_prompt = match (base_prompt, memory_context) {
+        (Some(base), Some(mem)) => Some(format!("{}\n\n{}", base, mem)),
+        (Some(base), None) => Some(base),
+        (None, Some(mem)) => Some(mem),
+        (None, None) => None,
     };
 
     // Resolve linked workspace directories
@@ -829,7 +861,7 @@ pub async fn send_followup_message(
 
     let permission_mode = resolve_permission_mode(disable_plan_mode);
 
-    let cmd = claude_process::SidecarCommand::Query {
+    let mut cmd = claude_process::SidecarCommand::Query {
         id: id.to_string(),
         prompt: message,
         cwd,
@@ -842,7 +874,25 @@ pub async fn send_followup_message(
         disable_thinking: None,
         repo_id: Some(repo_id_for_memory),
         memory_enabled: Some(true),
+        mempalace_python_cmd: None,
+        mempalace_palace_path: None,
     };
+
+    // If MemPalace is enabled, detect and populate config
+    {
+        let mp_settings = state.settings.read().unwrap().mempalace.clone();
+        if mp_settings.enabled {
+            if let Some(py_cmd) = crate::services::mempalace::detect_python(mp_settings.python_command.as_deref()).await {
+                if crate::services::mempalace::detect_mempalace(&py_cmd).await.is_some() {
+                    let palace_path = crate::services::mempalace::resolve_palace_path(mp_settings.palace_path.as_deref());
+                    if let claude_process::SidecarCommand::Query { ref mut mempalace_python_cmd, ref mut mempalace_palace_path, .. } = cmd {
+                        *mempalace_python_cmd = Some(py_cmd);
+                        *mempalace_palace_path = Some(palace_path);
+                    }
+                }
+            }
+        }
+    }
 
     let mut guard = state.agent_sidecar.lock().await;
     let handle = guard.as_mut().ok_or_else(|| {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -423,10 +423,39 @@ pub async fn send_message(
         vec![]
     };
 
-    // Get system prompt additions
+    // Get system prompt additions + memory context (Layer 1)
+    let repo_id_for_memory = if let Some(workspace_id) = request.workspace_id {
+        let workspaces = state.workspaces.read().unwrap();
+        workspaces.get(&workspace_id).map(|ws| ws.repo_id.to_string())
+    } else {
+        request.repo_id.map(|id| id.to_string())
+    };
+
     let system_prompt = {
         let settings = state.settings.read().unwrap();
-        settings.system_prompt_additions.clone()
+        let base_prompt = settings.system_prompt_additions.clone();
+
+        // Build memory context from DB snapshots
+        let memory_context = {
+            let ws_id = context_id.to_string();
+
+            if let Some(rid) = repo_id_for_memory.as_deref() {
+                let db_guard = state.db.lock().unwrap_or_else(|e| e.into_inner());
+                db_guard.as_ref().and_then(|db| {
+                    db.build_memory_context(&ws_id, rid).ok().flatten()
+                })
+            } else {
+                None
+            }
+        };
+
+        // Combine: base prompt + memory context
+        match (base_prompt, memory_context) {
+            (Some(base), Some(mem)) => Some(format!("{}\n\n{}", base, mem)),
+            (Some(base), None) => Some(base),
+            (None, Some(mem)) => Some(mem),
+            (None, None) => None,
+        }
     };
 
     let (disable_thinking, disable_plan_mode) = extract_toggle_flags(&request);
@@ -493,6 +522,8 @@ pub async fn send_message(
             env_vars: Some(env_vars),
             additional_dirs: Some(linked_dirs.iter().map(|d| d.to_string_lossy().to_string()).collect()),
             disable_thinking: Some(disable_thinking),
+            repo_id: repo_id_for_memory.clone(),
+            memory_enabled: Some(true),
         };
 
         let mut guard = state.agent_sidecar.lock().await;
@@ -755,7 +786,7 @@ pub async fn send_followup_message(
     };
 
     // Bug #4 fix: Look up workspace, repo, and build env vars + system prompt
-    let (cwd, env_vars) = {
+    let (cwd, env_vars, repo_id_for_memory) = {
         let workspaces = state.workspaces.read().unwrap();
         let ws = workspaces
             .get(&id)
@@ -770,7 +801,7 @@ pub async fn send_followup_message(
         let repo_settings = crate::commands::script::resolve_settings(&state, &repo.id).ok();
         let provider_override = repo_settings.as_ref().and_then(|s| s.provider_override.as_ref());
         let env = claude_process::build_env_vars(&ws, &repo, &settings, provider_override);
-        (ws.worktree_path.to_string_lossy().to_string(), env)
+        (ws.worktree_path.to_string_lossy().to_string(), env, ws.repo_id.to_string())
     };
 
     // Read system prompt from settings
@@ -809,6 +840,8 @@ pub async fn send_followup_message(
         env_vars: Some(env_vars),
         additional_dirs: Some(linked_dirs),
         disable_thinking: None,
+        repo_id: Some(repo_id_for_memory),
+        memory_enabled: Some(true),
     };
 
     let mut guard = state.agent_sidecar.lock().await;

--- a/src-tauri/src/commands/inline_edit.rs
+++ b/src-tauri/src/commands/inline_edit.rs
@@ -71,6 +71,10 @@ pub async fn inline_edit(
         env_vars: Some(env_vars),
         additional_dirs: None,
         disable_thinking: Some(true),
+        repo_id: None,
+        memory_enabled: None,
+        mempalace_python_cmd: None,
+        mempalace_palace_path: None,
     };
 
     let mut guard = state.agent_sidecar.lock().await;

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -1,0 +1,108 @@
+use crate::error::AppError;
+use crate::models::memory::{MemoryObservation, MemorySnapshot, SaveLearningRequest};
+use crate::state::AppState;
+use tauri::State;
+
+/// List memory observations for a workspace.
+#[tauri::command]
+#[specta::specta]
+pub async fn list_memory_observations(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    limit: Option<usize>,
+) -> Result<Vec<MemoryObservation>, AppError> {
+    let limit = limit.unwrap_or(50);
+    state.with_db(move |db| db.list_memory_observations(&workspace_id, limit))
+        .await
+}
+
+/// Search memory observations across scopes.
+#[tauri::command]
+#[specta::specta]
+pub async fn search_memory(
+    state: State<'_, AppState>,
+    query: String,
+    scope: String,
+    scope_id: Option<String>,
+    limit: Option<usize>,
+) -> Result<Vec<MemoryObservation>, AppError> {
+    let limit = limit.unwrap_or(10);
+    state.with_db(move |db| {
+        db.search_memory_observations(&query, &scope, scope_id.as_deref(), limit)
+    })
+    .await
+}
+
+/// Get memory snapshots for a scope.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_memory_snapshots(
+    state: State<'_, AppState>,
+    scope: String,
+    scope_id: Option<String>,
+) -> Result<Vec<MemorySnapshot>, AppError> {
+    state.with_db(move |db| db.get_memory_snapshots(&scope, scope_id.as_deref()))
+        .await
+}
+
+/// Build the full memory context for a workspace (for debugging/preview).
+#[tauri::command]
+#[specta::specta]
+pub async fn get_memory_context(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    repo_id: String,
+) -> Result<Option<String>, AppError> {
+    state.with_db(move |db| db.build_memory_context(&workspace_id, &repo_id))
+        .await
+}
+
+/// Save a learning manually (user or agent-initiated).
+#[tauri::command]
+#[specta::specta]
+pub async fn save_memory_learning(
+    state: State<'_, AppState>,
+    request: SaveLearningRequest,
+) -> Result<(), AppError> {
+    let snapshot = MemorySnapshot {
+        id: uuid::Uuid::new_v4().to_string(),
+        scope: request.scope,
+        scope_id: if request.scope == "global" {
+            None
+        } else if request.scope == "repo" {
+            Some(request.repo_id.clone())
+        } else {
+            Some(request.workspace_id.clone())
+        },
+        category: request.category,
+        content: format!("- {}", request.content),
+        observation_ids: vec![],
+        created_at: chrono::Utc::now().to_rfc3339(),
+        supersedes: None,
+    };
+    state.with_db(move |db| db.upsert_memory_snapshot(&snapshot))
+        .await
+}
+
+/// Clear all memory for a workspace.
+#[tauri::command]
+#[specta::specta]
+pub async fn clear_workspace_memory(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<(), AppError> {
+    state.with_db(move |db| db.clear_workspace_memory(&workspace_id))
+        .await
+}
+
+/// Prune old observations (called periodically or from settings).
+#[tauri::command]
+#[specta::specta]
+pub async fn prune_memory_observations(
+    state: State<'_, AppState>,
+    older_than_days: Option<i64>,
+) -> Result<usize, AppError> {
+    let days = older_than_days.unwrap_or(30);
+    state.with_db(move |db| db.prune_old_observations(days))
+        .await
+}

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -64,16 +64,17 @@ pub async fn save_memory_learning(
     state: State<'_, AppState>,
     request: SaveLearningRequest,
 ) -> Result<(), AppError> {
+    let scope_id = if request.scope == "global" {
+        None
+    } else if request.scope == "repo" {
+        Some(request.repo_id.clone())
+    } else {
+        Some(request.workspace_id.clone())
+    };
     let snapshot = MemorySnapshot {
         id: uuid::Uuid::new_v4().to_string(),
         scope: request.scope,
-        scope_id: if request.scope == "global" {
-            None
-        } else if request.scope == "repo" {
-            Some(request.repo_id.clone())
-        } else {
-            Some(request.workspace_id.clone())
-        },
+        scope_id,
         category: request.category,
         content: format!("- {}", request.content),
         observation_ids: vec![],

--- a/src-tauri/src/commands/mempalace.rs
+++ b/src-tauri/src/commands/mempalace.rs
@@ -1,0 +1,104 @@
+use crate::error::AppError;
+use crate::services::mempalace::{self, MemPalaceStatus};
+use crate::state::AppState;
+use tauri::State;
+
+/// Get the current status of the MemPalace integration.
+#[tauri::command]
+#[specta::specta]
+pub async fn check_mempalace_status(
+    state: State<'_, AppState>,
+) -> Result<MemPalaceStatus, AppError> {
+    let settings = state.settings.read().unwrap().clone();
+    Ok(mempalace::get_status(
+        settings.mempalace.python_command.as_deref(),
+        settings.mempalace.palace_path.as_deref(),
+    )
+    .await)
+}
+
+/// Initialize a MemPalace palace directory.
+#[tauri::command]
+#[specta::specta]
+pub async fn initialize_mempalace_palace(
+    state: State<'_, AppState>,
+) -> Result<(), AppError> {
+    let settings = state.settings.read().unwrap().clone();
+    let python_cmd = mempalace::detect_python(settings.mempalace.python_command.as_deref())
+        .await
+        .ok_or_else(|| AppError::AgentError("Python not found".to_string()))?;
+    let palace_path = mempalace::resolve_palace_path(settings.mempalace.palace_path.as_deref());
+    mempalace::initialize_palace(&python_cmd, &palace_path).await
+}
+
+/// Install mempalace via pipx, uv, or pip.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_mempalace_package(
+    state: State<'_, AppState>,
+) -> Result<String, AppError> {
+    let settings = state.settings.read().unwrap().clone();
+    let python_cmd = mempalace::detect_python(settings.mempalace.python_command.as_deref())
+        .await
+        .ok_or_else(|| AppError::AgentError("Python not found".to_string()))?;
+    mempalace::install_mempalace(&python_cmd).await
+}
+
+/// Migrate existing SQLite memory snapshots to MemPalace drawers.
+/// No-op if already migrated.
+#[tauri::command]
+#[specta::specta]
+pub async fn migrate_memory_to_mempalace(
+    state: State<'_, AppState>,
+) -> Result<u32, AppError> {
+    // Check if already migrated
+    let already_migrated = state
+        .with_db(|db| Ok(db.is_mempalace_migrated()))
+        .await?;
+    if already_migrated {
+        return Ok(0);
+    }
+
+    let settings = state.settings.read().unwrap().clone();
+    let python_cmd = mempalace::detect_python(settings.mempalace.python_command.as_deref())
+        .await
+        .ok_or_else(|| AppError::AgentError("Python not found".to_string()))?;
+
+    if mempalace::detect_mempalace(&python_cmd).await.is_none() {
+        return Err(AppError::AgentError("MemPalace not installed".to_string()));
+    }
+
+    let palace_path = mempalace::resolve_palace_path(settings.mempalace.palace_path.as_deref());
+
+    // Read all snapshots from SQLite
+    let snapshots = state
+        .with_db(|db| db.get_all_memory_snapshots())
+        .await?;
+
+    if snapshots.is_empty() {
+        state.with_db(|db| db.set_mempalace_migrated()).await?;
+        return Ok(0);
+    }
+
+    // Convert snapshots to MemPalace sync entries
+    let entries: Vec<mempalace::MemPalaceSyncEntry> = snapshots
+        .iter()
+        .map(|snap| {
+            let repo_name = snap.scope_id.clone().unwrap_or_default();
+            mempalace::MemPalaceSyncEntry {
+                content: snap.content.clone(),
+                category: snap.category.clone(),
+                repo_name,
+                file_paths: vec![],
+            }
+        })
+        .collect();
+
+    let count = entries.len();
+    mempalace::sync_observations_to_mempalace(&python_cmd, &palace_path, entries).await?;
+
+    // Mark migration as complete
+    state.with_db(|db| db.set_mempalace_migrated()).await?;
+
+    Ok(count as u32)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod git_diff;
 pub mod linear;
 pub mod lsp;
 pub mod mcp;
+pub mod mempalace;
 pub mod memory;
 pub mod merge;
 pub mod perf;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod git_diff;
 pub mod linear;
 pub mod lsp;
 pub mod mcp;
+pub mod memory;
 pub mod merge;
 pub mod perf;
 pub mod pr;

--- a/src-tauri/src/db/memory.rs
+++ b/src-tauri/src/db/memory.rs
@@ -288,6 +288,66 @@ impl Database {
         Ok(affected)
     }
 
+    /// Get all memory snapshots for MemPalace migration.
+    pub fn get_all_memory_snapshots(&self) -> Result<Vec<MemorySnapshot>, AppError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, scope, scope_id, category, content, observation_ids,
+                        created_at, supersedes
+                 FROM memory_snapshots
+                 ORDER BY created_at ASC",
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let obs_ids_str: String = row.get(5)?;
+                let observation_ids: Vec<String> =
+                    serde_json::from_str(&obs_ids_str).unwrap_or_default();
+                Ok(MemorySnapshot {
+                    id: row.get(0)?,
+                    scope: row.get(1)?,
+                    scope_id: row.get(2)?,
+                    category: row.get(3)?,
+                    content: row.get(4)?,
+                    observation_ids,
+                    created_at: row.get(6)?,
+                    supersedes: row.get(7)?,
+                })
+            })
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(|e| AppError::DbError(e.to_string()))?);
+        }
+        Ok(results)
+    }
+
+    /// Check if MemPalace migration has been completed.
+    pub fn is_mempalace_migrated(&self) -> bool {
+        self.conn
+            .query_row(
+                "SELECT value FROM kv_meta WHERE key = 'mempalace_migrated'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .map(|v| v == "true")
+            .unwrap_or(false)
+    }
+
+    /// Mark MemPalace migration as completed.
+    pub fn set_mempalace_migrated(&self) -> Result<(), AppError> {
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('mempalace_migrated', 'true')",
+                [],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        Ok(())
+    }
+
     /// Delete all memory data for a workspace.
     pub fn clear_workspace_memory(&self, workspace_id: &str) -> Result<(), AppError> {
         self.conn

--- a/src-tauri/src/db/memory.rs
+++ b/src-tauri/src/db/memory.rs
@@ -1,0 +1,465 @@
+use crate::error::AppError;
+use crate::models::memory::{MemoryObservation, MemorySnapshot};
+
+use super::Database;
+
+impl Database {
+    /// Insert a new memory observation extracted from an agent session.
+    pub fn insert_memory_observation(&self, obs: &MemoryObservation) -> Result<(), AppError> {
+        let file_paths_json = serde_json::to_string(&obs.file_paths).unwrap_or_default();
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO memory_observations
+                 (id, workspace_id, repo_id, session_id, observation_type, content,
+                  compressed_content, source_tool, file_paths, tokens_raw, tokens_compressed, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                rusqlite::params![
+                    obs.id,
+                    obs.workspace_id,
+                    obs.repo_id,
+                    obs.session_id,
+                    obs.observation_type,
+                    obs.content,
+                    obs.compressed_content,
+                    obs.source_tool,
+                    file_paths_json,
+                    obs.tokens_raw,
+                    obs.tokens_compressed,
+                    obs.created_at,
+                ],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        Ok(())
+    }
+
+    /// List observations for a workspace, ordered by creation time descending.
+    pub fn list_memory_observations(
+        &self,
+        workspace_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryObservation>, AppError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, workspace_id, repo_id, session_id, observation_type, content,
+                        compressed_content, source_tool, file_paths, tokens_raw,
+                        tokens_compressed, created_at, accessed_at
+                 FROM memory_observations
+                 WHERE workspace_id = ?1
+                 ORDER BY created_at DESC
+                 LIMIT ?2",
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![workspace_id, limit], |row| {
+                let file_paths_str: String = row.get(8)?;
+                let file_paths: Vec<String> =
+                    serde_json::from_str(&file_paths_str).unwrap_or_default();
+                Ok(MemoryObservation {
+                    id: row.get(0)?,
+                    workspace_id: row.get(1)?,
+                    repo_id: row.get(2)?,
+                    session_id: row.get(3)?,
+                    observation_type: row.get(4)?,
+                    content: row.get(5)?,
+                    compressed_content: row.get(6)?,
+                    source_tool: row.get(7)?,
+                    file_paths,
+                    tokens_raw: row.get(9)?,
+                    tokens_compressed: row.get(10)?,
+                    created_at: row.get(11)?,
+                    accessed_at: row.get(12)?,
+                })
+            })
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(|e| AppError::DbError(e.to_string()))?);
+        }
+        Ok(results)
+    }
+
+    /// Search observations using LIKE queries on content.
+    pub fn search_memory_observations(
+        &self,
+        query: &str,
+        scope: &str,
+        scope_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<MemoryObservation>, AppError> {
+        let like_pattern = format!("%{}%", query);
+        let (sql, params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = match scope {
+            "workspace" => (
+                "SELECT id, workspace_id, repo_id, session_id, observation_type, content,
+                        compressed_content, source_tool, file_paths, tokens_raw,
+                        tokens_compressed, created_at, accessed_at
+                 FROM memory_observations
+                 WHERE workspace_id = ?1 AND (content LIKE ?2 OR compressed_content LIKE ?2)
+                 ORDER BY created_at DESC LIMIT ?3",
+                vec![
+                    Box::new(scope_id.unwrap_or("").to_string()),
+                    Box::new(like_pattern),
+                    Box::new(limit as i64),
+                ],
+            ),
+            "repo" => (
+                "SELECT id, workspace_id, repo_id, session_id, observation_type, content,
+                        compressed_content, source_tool, file_paths, tokens_raw,
+                        tokens_compressed, created_at, accessed_at
+                 FROM memory_observations
+                 WHERE repo_id = ?1 AND (content LIKE ?2 OR compressed_content LIKE ?2)
+                 ORDER BY created_at DESC LIMIT ?3",
+                vec![
+                    Box::new(scope_id.unwrap_or("").to_string()),
+                    Box::new(like_pattern),
+                    Box::new(limit as i64),
+                ],
+            ),
+            _ => (
+                "SELECT id, workspace_id, repo_id, session_id, observation_type, content,
+                        compressed_content, source_tool, file_paths, tokens_raw,
+                        tokens_compressed, created_at, accessed_at
+                 FROM memory_observations
+                 WHERE content LIKE ?1 OR compressed_content LIKE ?1
+                 ORDER BY created_at DESC LIMIT ?2",
+                vec![
+                    Box::new(like_pattern),
+                    Box::new(limit as i64),
+                ],
+            ),
+        };
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let file_paths_str: String = row.get(8)?;
+                let file_paths: Vec<String> =
+                    serde_json::from_str(&file_paths_str).unwrap_or_default();
+                Ok(MemoryObservation {
+                    id: row.get(0)?,
+                    workspace_id: row.get(1)?,
+                    repo_id: row.get(2)?,
+                    session_id: row.get(3)?,
+                    observation_type: row.get(4)?,
+                    content: row.get(5)?,
+                    compressed_content: row.get(6)?,
+                    source_tool: row.get(7)?,
+                    file_paths,
+                    tokens_raw: row.get(9)?,
+                    tokens_compressed: row.get(10)?,
+                    created_at: row.get(11)?,
+                    accessed_at: row.get(12)?,
+                })
+            })
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(|e| AppError::DbError(e.to_string()))?);
+        }
+        Ok(results)
+    }
+
+    /// Insert or replace a memory snapshot (compressed context for injection).
+    pub fn upsert_memory_snapshot(&self, snapshot: &MemorySnapshot) -> Result<(), AppError> {
+        let obs_ids_json =
+            serde_json::to_string(&snapshot.observation_ids).unwrap_or_default();
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO memory_snapshots
+                 (id, scope, scope_id, category, content, observation_ids, created_at, supersedes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    snapshot.id,
+                    snapshot.scope,
+                    snapshot.scope_id,
+                    snapshot.category,
+                    snapshot.content,
+                    obs_ids_json,
+                    snapshot.created_at,
+                    snapshot.supersedes,
+                ],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Get all active snapshots for a given scope (workspace, repo, or global).
+    pub fn get_memory_snapshots(
+        &self,
+        scope: &str,
+        scope_id: Option<&str>,
+    ) -> Result<Vec<MemorySnapshot>, AppError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, scope, scope_id, category, content, observation_ids,
+                        created_at, supersedes
+                 FROM memory_snapshots
+                 WHERE scope = ?1 AND (scope_id = ?2 OR (?2 IS NULL AND scope_id IS NULL))
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![scope, scope_id], |row| {
+                let obs_ids_str: String = row.get(5)?;
+                let observation_ids: Vec<String> =
+                    serde_json::from_str(&obs_ids_str).unwrap_or_default();
+                Ok(MemorySnapshot {
+                    id: row.get(0)?,
+                    scope: row.get(1)?,
+                    scope_id: row.get(2)?,
+                    category: row.get(3)?,
+                    content: row.get(4)?,
+                    observation_ids,
+                    created_at: row.get(6)?,
+                    supersedes: row.get(7)?,
+                })
+            })
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(|e| AppError::DbError(e.to_string()))?);
+        }
+        Ok(results)
+    }
+
+    /// Build the full memory context string for a workspace (used by Layer 1).
+    /// Returns markdown to append to the system prompt.
+    pub fn build_memory_context(
+        &self,
+        workspace_id: &str,
+        repo_id: &str,
+    ) -> Result<Option<String>, AppError> {
+        let mut sections: Vec<String> = Vec::new();
+
+        // Global preferences
+        let global = self.get_memory_snapshots("global", None)?;
+        if !global.is_empty() {
+            let items: Vec<String> = global.iter().map(|s| s.content.clone()).collect();
+            sections.push(format!("### User Preferences\n{}", items.join("\n")));
+        }
+
+        // Repo-level patterns
+        let repo = self.get_memory_snapshots("repo", Some(repo_id))?;
+        if !repo.is_empty() {
+            let items: Vec<String> = repo.iter().map(|s| s.content.clone()).collect();
+            sections.push(format!("### Project Patterns\n{}", items.join("\n")));
+        }
+
+        // Workspace-specific context
+        let ws = self.get_memory_snapshots("workspace", Some(workspace_id))?;
+        if !ws.is_empty() {
+            let items: Vec<String> = ws.iter().map(|s| s.content.clone()).collect();
+            sections.push(format!("### Workspace Context\n{}", items.join("\n")));
+        }
+
+        if sections.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(format!(
+            "## Project Memory\n\n{}",
+            sections.join("\n\n")
+        )))
+    }
+
+    /// Delete observations older than the given number of days that haven't been accessed.
+    pub fn prune_old_observations(&self, older_than_days: i64) -> Result<usize, AppError> {
+        let affected = self
+            .conn
+            .execute(
+                "DELETE FROM memory_observations
+                 WHERE created_at < datetime('now', ?1)
+                 AND (accessed_at IS NULL OR accessed_at < datetime('now', ?1))",
+                rusqlite::params![format!("-{} days", older_than_days)],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        Ok(affected)
+    }
+
+    /// Delete all memory data for a workspace.
+    pub fn clear_workspace_memory(&self, workspace_id: &str) -> Result<(), AppError> {
+        self.conn
+            .execute(
+                "DELETE FROM memory_observations WHERE workspace_id = ?1",
+                rusqlite::params![workspace_id],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        self.conn
+            .execute(
+                "DELETE FROM memory_snapshots WHERE scope = 'workspace' AND scope_id = ?1",
+                rusqlite::params![workspace_id],
+            )
+            .map_err(|e| AppError::DbError(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::Database;
+    use crate::models::memory::{MemoryObservation, MemorySnapshot};
+
+    fn test_db() -> Database {
+        Database::init_in_memory().unwrap()
+    }
+
+    #[test]
+    fn test_insert_and_list_observations() {
+        let db = test_db();
+        let obs = MemoryObservation {
+            id: "obs-1".to_string(),
+            workspace_id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            session_id: Some("sess-1".to_string()),
+            observation_type: "decision".to_string(),
+            content: "Chose Zustand over Redux".to_string(),
+            compressed_content: None,
+            source_tool: Some("Edit".to_string()),
+            file_paths: vec!["src/store.ts".to_string()],
+            tokens_raw: Some(50),
+            tokens_compressed: None,
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            accessed_at: None,
+        };
+        db.insert_memory_observation(&obs).unwrap();
+
+        let results = db.list_memory_observations("ws-1", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "Chose Zustand over Redux");
+        assert_eq!(results[0].file_paths, vec!["src/store.ts"]);
+    }
+
+    #[test]
+    fn test_search_observations() {
+        let db = test_db();
+        let obs = MemoryObservation {
+            id: "obs-2".to_string(),
+            workspace_id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            session_id: None,
+            observation_type: "error".to_string(),
+            content: "cargo build failed: missing lifetime".to_string(),
+            compressed_content: None,
+            source_tool: Some("Bash".to_string()),
+            file_paths: vec![],
+            tokens_raw: None,
+            tokens_compressed: None,
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            accessed_at: None,
+        };
+        db.insert_memory_observation(&obs).unwrap();
+
+        let results = db
+            .search_memory_observations("lifetime", "workspace", Some("ws-1"), 10)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+
+        let no_results = db
+            .search_memory_observations("nonexistent", "workspace", Some("ws-1"), 10)
+            .unwrap();
+        assert_eq!(no_results.len(), 0);
+    }
+
+    #[test]
+    fn test_upsert_and_get_snapshots() {
+        let db = test_db();
+        let snapshot = MemorySnapshot {
+            id: "snap-1".to_string(),
+            scope: "workspace".to_string(),
+            scope_id: Some("ws-1".to_string()),
+            category: "decisions".to_string(),
+            content: "- Chose Zustand over Redux\n- Using barrel exports".to_string(),
+            observation_ids: vec!["obs-1".to_string(), "obs-2".to_string()],
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            supersedes: None,
+        };
+        db.upsert_memory_snapshot(&snapshot).unwrap();
+
+        let results = db
+            .get_memory_snapshots("workspace", Some("ws-1"))
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].category, "decisions");
+        assert_eq!(results[0].observation_ids.len(), 2);
+    }
+
+    #[test]
+    fn test_build_memory_context_empty() {
+        let db = test_db();
+        let ctx = db.build_memory_context("ws-1", "repo-1").unwrap();
+        assert!(ctx.is_none());
+    }
+
+    #[test]
+    fn test_build_memory_context_with_data() {
+        let db = test_db();
+        db.upsert_memory_snapshot(&MemorySnapshot {
+            id: "snap-g".to_string(),
+            scope: "global".to_string(),
+            scope_id: None,
+            category: "preferences".to_string(),
+            content: "- Prefers TypeScript strict mode".to_string(),
+            observation_ids: vec![],
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            supersedes: None,
+        })
+        .unwrap();
+
+        db.upsert_memory_snapshot(&MemorySnapshot {
+            id: "snap-r".to_string(),
+            scope: "repo".to_string(),
+            scope_id: Some("repo-1".to_string()),
+            category: "patterns".to_string(),
+            content: "- Uses Zustand for state management".to_string(),
+            observation_ids: vec![],
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            supersedes: None,
+        })
+        .unwrap();
+
+        let ctx = db.build_memory_context("ws-1", "repo-1").unwrap();
+        assert!(ctx.is_some());
+        let text = ctx.unwrap();
+        assert!(text.contains("User Preferences"));
+        assert!(text.contains("Project Patterns"));
+        assert!(text.contains("TypeScript strict mode"));
+        assert!(text.contains("Zustand"));
+    }
+
+    #[test]
+    fn test_clear_workspace_memory() {
+        let db = test_db();
+        let obs = MemoryObservation {
+            id: "obs-del".to_string(),
+            workspace_id: "ws-del".to_string(),
+            repo_id: "repo-1".to_string(),
+            session_id: None,
+            observation_type: "pattern".to_string(),
+            content: "test content".to_string(),
+            compressed_content: None,
+            source_tool: None,
+            file_paths: vec![],
+            tokens_raw: None,
+            tokens_compressed: None,
+            created_at: "2026-04-08T12:00:00Z".to_string(),
+            accessed_at: None,
+        };
+        db.insert_memory_observation(&obs).unwrap();
+        assert_eq!(db.list_memory_observations("ws-del", 10).unwrap().len(), 1);
+
+        db.clear_workspace_memory("ws-del").unwrap();
+        assert_eq!(db.list_memory_observations("ws-del", 10).unwrap().len(), 0);
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -355,5 +355,16 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     )
     .map_err(|e| AppError::DbError(e.to_string()))?;
 
+    // Key-value metadata table for migration flags and misc state
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS kv_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        ",
+    )
+    .map_err(|e| AppError::DbError(e.to_string()))?;
+
     Ok(())
 }

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -312,5 +312,48 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     )
     .map_err(|e| AppError::DbError(e.to_string()))?;
 
+    // Memory system tables — observations extracted from agent sessions
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS memory_observations (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL,
+            repo_id TEXT NOT NULL,
+            session_id TEXT,
+            observation_type TEXT NOT NULL,
+            content TEXT NOT NULL,
+            compressed_content TEXT,
+            source_tool TEXT,
+            file_paths TEXT,
+            tokens_raw INTEGER,
+            tokens_compressed INTEGER,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            accessed_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_obs_workspace ON memory_observations(workspace_id);
+        CREATE INDEX IF NOT EXISTS idx_obs_repo ON memory_observations(repo_id);
+        CREATE INDEX IF NOT EXISTS idx_obs_type ON memory_observations(observation_type);
+        ",
+    )
+    .map_err(|e| AppError::DbError(e.to_string()))?;
+
+    // Memory snapshots — compressed summaries used for context injection
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS memory_snapshots (
+            id TEXT PRIMARY KEY,
+            scope TEXT NOT NULL,
+            scope_id TEXT,
+            category TEXT NOT NULL,
+            content TEXT NOT NULL,
+            observation_ids TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            supersedes TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_snap_scope ON memory_snapshots(scope, scope_id);
+        ",
+    )
+    .map_err(|e| AppError::DbError(e.to_string()))?;
+
     Ok(())
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -8,6 +8,7 @@ mod settings;
 mod templates;
 mod todos;
 mod workspaces;
+mod memory;
 mod notepads;
 
 use crate::error::AppError;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -290,6 +290,14 @@ fn specta_builder() -> tauri_specta::Builder {
             // Inline edit commands
             commands::inline_edit::inline_edit,
             commands::inline_edit::cancel_inline_edit,
+            // Memory commands
+            commands::memory::list_memory_observations,
+            commands::memory::search_memory,
+            commands::memory::get_memory_snapshots,
+            commands::memory::get_memory_context,
+            commands::memory::save_memory_learning,
+            commands::memory::clear_workspace_memory,
+            commands::memory::prune_memory_observations,
         ]);
 
     builder

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,11 @@ fn specta_builder() -> tauri_specta::Builder {
             commands::memory::save_memory_learning,
             commands::memory::clear_workspace_memory,
             commands::memory::prune_memory_observations,
+            // MemPalace commands
+            commands::mempalace::check_mempalace_status,
+            commands::mempalace::initialize_mempalace_palace,
+            commands::mempalace::install_mempalace_package,
+            commands::mempalace::migrate_memory_to_mempalace,
         ]);
 
     builder

--- a/src-tauri/src/models/memory.rs
+++ b/src-tauri/src/models/memory.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+/// A single observation extracted from an agent session via hooks.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryObservation {
+    pub id: String,
+    pub workspace_id: String,
+    pub repo_id: String,
+    pub session_id: Option<String>,
+    pub observation_type: String,
+    pub content: String,
+    pub compressed_content: Option<String>,
+    pub source_tool: Option<String>,
+    pub file_paths: Vec<String>,
+    pub tokens_raw: Option<i64>,
+    pub tokens_compressed: Option<i64>,
+    pub created_at: String,
+    pub accessed_at: Option<String>,
+}
+
+/// A compressed memory snapshot used for context injection (Layer 1).
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MemorySnapshot {
+    pub id: String,
+    pub scope: String,
+    pub scope_id: Option<String>,
+    pub category: String,
+    pub content: String,
+    pub observation_ids: Vec<String>,
+    pub created_at: String,
+    pub supersedes: Option<String>,
+}
+
+/// Event emitted from the sidecar when an observation is extracted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryObservationEvent {
+    pub observation_type: String,
+    pub content: String,
+    pub source_tool: Option<String>,
+    pub file_paths: Vec<String>,
+    pub session_id: Option<String>,
+}
+
+/// Request to save a learning via the MCP tool or Tauri command.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveLearningRequest {
+    pub workspace_id: String,
+    pub repo_id: String,
+    pub content: String,
+    pub category: String,
+    pub scope: String,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod export;
 pub mod linear;
 pub mod lsp;
 pub mod mcp;
+pub mod memory;
 pub mod merge;
 pub mod pr;
 pub mod prompt;

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -29,6 +29,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub claude_context: ClaudeContextSettings,
     #[serde(default)]
+    pub mempalace: MemPalaceSettings,
+    #[serde(default)]
     pub custom_themes: Vec<CustomTheme>,
 }
 
@@ -45,6 +47,7 @@ impl Default for AppSettings {
             linear: LinearSettings::default(),
             azure_devops: AzureDevOpsSettings::default(),
             claude_context: ClaudeContextSettings::default(),
+            mempalace: MemPalaceSettings::default(),
             custom_themes: Vec::new(),
         }
     }
@@ -140,6 +143,26 @@ pub struct ClaudeContextSettings {
     pub openai_api_key: Option<String>,
     pub zilliz_uri: Option<String>,
     pub zilliz_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MemPalaceSettings {
+    pub enabled: bool,
+    #[serde(default)]
+    pub palace_path: Option<String>,
+    #[serde(default)]
+    pub python_command: Option<String>,
+}
+
+impl Default for MemPalaceSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            palace_path: None,
+            python_command: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/claude_process/sidecar.rs
+++ b/src-tauri/src/services/claude_process/sidecar.rs
@@ -45,6 +45,10 @@ pub enum SidecarCommand {
         additional_dirs: Option<Vec<String>>,
         #[serde(rename = "disableThinking", skip_serializing_if = "Option::is_none")]
         disable_thinking: Option<bool>,
+        #[serde(rename = "repoId", skip_serializing_if = "Option::is_none")]
+        repo_id: Option<String>,
+        #[serde(rename = "memoryEnabled", skip_serializing_if = "Option::is_none")]
+        memory_enabled: Option<bool>,
     },
     PermissionResponse {
         id: String,
@@ -195,6 +199,51 @@ pub(crate) fn handle_sidecar_line<R: tauri::Runtime>(
     db: &Arc<Mutex<Option<Database>>>,
 ) -> Result<(), String> {
     let (workspace_id, raw) = parse_sidecar_line_id(line)?;
+
+    // Handle memory observation events from hooks (Layer 2)
+    if raw.get("type").and_then(|v| v.as_str()) == Some("memory_observation") {
+        if let Some(obs_data) = raw.get("observation") {
+            if let Ok(obs_event) = serde_json::from_value::<crate::models::memory::MemoryObservationEvent>(obs_data.clone()) {
+                // Resolve repo_id from workspace
+                let repo_id = raw.get("repo_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let observation = crate::models::memory::MemoryObservation {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    workspace_id: workspace_id.to_string(),
+                    repo_id,
+                    session_id: obs_event.session_id,
+                    observation_type: obs_event.observation_type,
+                    content: obs_event.content,
+                    compressed_content: None,
+                    source_tool: obs_event.source_tool,
+                    file_paths: obs_event.file_paths,
+                    tokens_raw: None,
+                    tokens_compressed: None,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    accessed_at: None,
+                };
+                if let Ok(guard) = db.lock() {
+                    if let Some(database) = guard.as_ref() {
+                        let _ = database.insert_memory_observation(&observation);
+                    }
+                }
+            }
+        }
+        return Ok(()); // Memory events don't get forwarded to frontend
+    }
+
+    // Handle memory snapshot events (compressed observations)
+    if raw.get("type").and_then(|v| v.as_str()) == Some("memory_snapshot") {
+        if let Ok(snapshot) = serde_json::from_value::<crate::models::memory::MemorySnapshot>(
+            raw.get("snapshot").cloned().unwrap_or_default(),
+        ) {
+            if let Ok(guard) = db.lock() {
+                if let Some(database) = guard.as_ref() {
+                    let _ = database.upsert_memory_snapshot(&snapshot);
+                }
+            }
+        }
+        return Ok(()); // Memory events don't get forwarded to frontend
+    }
 
     // Parse stream events using the existing parser
     let events = super::parse_stream_line(line);

--- a/src-tauri/src/services/claude_process/sidecar.rs
+++ b/src-tauri/src/services/claude_process/sidecar.rs
@@ -49,6 +49,10 @@ pub enum SidecarCommand {
         repo_id: Option<String>,
         #[serde(rename = "memoryEnabled", skip_serializing_if = "Option::is_none")]
         memory_enabled: Option<bool>,
+        #[serde(rename = "mempalacePythonCmd", skip_serializing_if = "Option::is_none")]
+        mempalace_python_cmd: Option<String>,
+        #[serde(rename = "mempalacePalacePath", skip_serializing_if = "Option::is_none")]
+        mempalace_palace_path: Option<String>,
     },
     PermissionResponse {
         id: String,
@@ -245,6 +249,65 @@ pub(crate) fn handle_sidecar_line<R: tauri::Runtime>(
         return Ok(()); // Memory events don't get forwarded to frontend
     }
 
+    // Handle MemPalace sync events (batch observations → MemPalace drawers)
+    if raw.get("type").and_then(|v| v.as_str()) == Some("mempalace_sync") {
+        let repo_name = raw
+            .get("repoName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default")
+            .to_string();
+        let observations: Vec<serde_json::Value> = raw
+            .get("observations")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        if !observations.is_empty() {
+            // Read MemPalace settings
+            let (python_cmd, palace_path) = {
+                let settings = app.state::<crate::state::AppState>();
+                let mp = settings.settings.read().unwrap().mempalace.clone();
+                let py = mp.python_command.clone().unwrap_or_else(|| "python3".to_string());
+                let path = crate::services::mempalace::resolve_palace_path(mp.palace_path.as_deref());
+                (py, path)
+            };
+
+            let entries: Vec<crate::services::mempalace::MemPalaceSyncEntry> = observations
+                .into_iter()
+                .filter_map(|obs| {
+                    Some(crate::services::mempalace::MemPalaceSyncEntry {
+                        content: obs.get("content")?.as_str()?.to_string(),
+                        category: obs.get("category")?.as_str()?.to_string(),
+                        repo_name: repo_name.clone(),
+                        file_paths: obs
+                            .get("filePaths")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                    })
+                })
+                .collect();
+
+            // Spawn async task — don't block the event loop
+            tokio::spawn(async move {
+                if let Err(e) = crate::services::mempalace::sync_observations_to_mempalace(
+                    &python_cmd,
+                    &palace_path,
+                    entries,
+                )
+                .await
+                {
+                    eprintln!("[mempalace] sync failed: {e}");
+                }
+            });
+        }
+        return Ok(());
+    }
+
     // Parse stream events using the existing parser
     let events = super::parse_stream_line(line);
 
@@ -353,6 +416,10 @@ mod tests {
             env_vars: None,
             additional_dirs: None,
             disable_thinking: None,
+            repo_id: None,
+            memory_enabled: None,
+            mempalace_python_cmd: None,
+            mempalace_palace_path: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"type\":\"query\""));
@@ -377,6 +444,10 @@ mod tests {
             env_vars: None,
             additional_dirs: Some(vec!["/extra".to_string()]),
             disable_thinking: Some(true),
+            repo_id: None,
+            memory_enabled: None,
+            mempalace_python_cmd: None,
+            mempalace_palace_path: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         // All fields must use camelCase to match TypeScript protocol

--- a/src-tauri/src/services/mempalace.rs
+++ b/src-tauri/src/services/mempalace.rs
@@ -1,0 +1,332 @@
+use crate::error::AppError;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tokio::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MemPalaceStatus {
+    pub python_available: bool,
+    pub python_command: Option<String>,
+    pub mempalace_installed: bool,
+    pub mempalace_version: Option<String>,
+    pub palace_initialized: bool,
+    pub palace_path: String,
+}
+
+/// Try `python3 --version`, then fall back to `python --version`.
+/// Returns the working command name (e.g. "python3" or "python").
+pub async fn detect_python(override_cmd: Option<&str>) -> Option<String> {
+    if let Some(cmd) = override_cmd {
+        if run_version_check(cmd).await.is_ok() {
+            return Some(cmd.to_string());
+        }
+        return None;
+    }
+    for cmd in &["python3", "python"] {
+        if run_version_check(cmd).await.is_ok() {
+            return Some(cmd.to_string());
+        }
+    }
+    None
+}
+
+async fn run_version_check(cmd: &str) -> Result<String, AppError> {
+    let output = Command::new(cmd)
+        .arg("--version")
+        .output()
+        .await
+        .map_err(|e| AppError::AgentError(format!("Failed to run {cmd}: {e}")))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(AppError::AgentError(format!("{cmd} --version failed")))
+    }
+}
+
+/// Check if `mempalace` is importable via the given Python command.
+/// Returns the version string on success.
+pub async fn detect_mempalace(python_cmd: &str) -> Option<String> {
+    let output = Command::new(python_cmd)
+        .args(["-m", "mempalace", "--version"])
+        .output()
+        .await
+        .ok()?;
+    if output.status.success() {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Some(if version.is_empty() {
+            String::from_utf8_lossy(&output.stderr).trim().to_string()
+        } else {
+            version
+        })
+    } else {
+        None
+    }
+}
+
+/// Resolve the palace path, defaulting to `~/.mempalace/palace`.
+pub fn resolve_palace_path(configured: Option<&str>) -> String {
+    if let Some(p) = configured {
+        return p.to_string();
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".mempalace").join("palace").to_string_lossy().to_string())
+        .unwrap_or_else(|| "~/.mempalace/palace".to_string())
+}
+
+/// Check if the palace directory exists.
+pub fn palace_exists(palace_path: &str) -> bool {
+    Path::new(palace_path).is_dir()
+}
+
+/// Initialize a MemPalace palace at the given path.
+pub async fn initialize_palace(python_cmd: &str, palace_path: &str) -> Result<(), AppError> {
+    let output = Command::new(python_cmd)
+        .args(["-m", "mempalace", "init", palace_path])
+        .output()
+        .await
+        .map_err(|e| AppError::AgentError(format!("Failed to run mempalace init: {e}")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(AppError::AgentError(format!(
+            "mempalace init failed: {stderr}"
+        )))
+    }
+}
+
+/// Install mempalace using pipx, uv, or pip (in that order of preference).
+pub async fn install_mempalace(python_cmd: &str) -> Result<String, AppError> {
+    // Try pipx first
+    if let Ok(output) = Command::new("pipx")
+        .args(["install", "mempalace"])
+        .output()
+        .await
+    {
+        if output.status.success() {
+            return Ok("Installed via pipx".to_string());
+        }
+    }
+
+    // Try uv tool
+    if let Ok(output) = Command::new("uv")
+        .args(["tool", "install", "mempalace"])
+        .output()
+        .await
+    {
+        if output.status.success() {
+            return Ok("Installed via uv".to_string());
+        }
+    }
+
+    // Fall back to pip install --user
+    let output = Command::new(python_cmd)
+        .args(["-m", "pip", "install", "--user", "mempalace"])
+        .output()
+        .await
+        .map_err(|e| AppError::AgentError(format!("pip install failed: {e}")))?;
+
+    if output.status.success() {
+        Ok("Installed via pip".to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(AppError::AgentError(format!(
+            "Failed to install mempalace: {stderr}"
+        )))
+    }
+}
+
+/// Get the full status of the MemPalace integration.
+pub async fn get_status(
+    configured_python: Option<&str>,
+    configured_palace_path: Option<&str>,
+) -> MemPalaceStatus {
+    let palace_path = resolve_palace_path(configured_palace_path);
+
+    let python_cmd = detect_python(configured_python).await;
+    let (mempalace_installed, mempalace_version) = if let Some(ref cmd) = python_cmd {
+        match detect_mempalace(cmd).await {
+            Some(v) => (true, Some(v)),
+            None => (false, None),
+        }
+    } else {
+        (false, None)
+    };
+
+    MemPalaceStatus {
+        python_available: python_cmd.is_some(),
+        python_command: python_cmd,
+        mempalace_installed,
+        mempalace_version,
+        palace_initialized: palace_exists(&palace_path),
+        palace_path,
+    }
+}
+
+/// Map a Fury observation category to a MemPalace wing/room pair.
+pub fn map_observation_to_drawer(
+    category: &str,
+    repo_name: &str,
+) -> (String, String) {
+    let wing = if repo_name.is_empty() {
+        "_global".to_string()
+    } else {
+        repo_name.to_string()
+    };
+    let room = match category {
+        "decision" => "decisions",
+        "pattern" => "patterns",
+        "error" => "errors",
+        "file_change" => "progress",
+        "preference" => "preferences",
+        _ => "general",
+    }
+    .to_string();
+    (wing, room)
+}
+
+/// Sync a batch of observations to MemPalace by spawning a one-shot MCP server process.
+pub async fn sync_observations_to_mempalace(
+    python_cmd: &str,
+    palace_path: &str,
+    observations: Vec<MemPalaceSyncEntry>,
+) -> Result<usize, AppError> {
+    if observations.is_empty() {
+        return Ok(0);
+    }
+
+    let mut child = tokio::process::Command::new(python_cmd)
+        .args(["-m", "mempalace.mcp_server", "--palace", palace_path])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| AppError::AgentError(format!("Failed to spawn mempalace MCP server: {e}")))?;
+
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| AppError::AgentError("No stdin on mempalace process".to_string()))?;
+
+    use tokio::io::AsyncWriteExt;
+    use tokio::io::AsyncBufReadExt;
+
+    // Send initialize request
+    let init_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "fury", "version": "1.0.0" }
+        }
+    });
+    let init_line = serde_json::to_string(&init_req)
+        .map_err(|e| AppError::AgentError(format!("JSON serialize error: {e}")))?;
+    stdin
+        .write_all(format!("{init_line}\n").as_bytes())
+        .await
+        .map_err(|e| AppError::AgentError(format!("Write to mempalace stdin: {e}")))?;
+
+    // Send each observation as a tools/call for mempalace_add_drawer
+    let mut synced = 0usize;
+    for (i, obs) in observations.iter().enumerate() {
+        let (wing, room) = map_observation_to_drawer(&obs.category, &obs.repo_name);
+        let req = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": i + 1,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {
+                    "wing": wing,
+                    "room": room,
+                    "content": obs.content,
+                    "added_by": "fury"
+                }
+            }
+        });
+        let line = serde_json::to_string(&req)
+            .map_err(|e| AppError::AgentError(format!("JSON serialize error: {e}")))?;
+        stdin
+            .write_all(format!("{line}\n").as_bytes())
+            .await
+            .map_err(|e| AppError::AgentError(format!("Write to mempalace stdin: {e}")))?;
+        synced += 1;
+    }
+
+    // Close stdin to signal EOF → server exits
+    drop(child.stdin.take());
+
+    // Read stdout to drain responses (don't block indefinitely)
+    if let Some(stdout) = child.stdout.take() {
+        let reader = tokio::io::BufReader::new(stdout);
+        let mut lines = reader.lines();
+        // Read up to synced+1 responses (init + N tool calls)
+        let expected = synced + 1;
+        for _ in 0..expected {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                lines.next_line(),
+            )
+            .await
+            {
+                Ok(Ok(Some(_))) => {}
+                _ => break,
+            }
+        }
+    }
+
+    // Wait for process exit (with timeout)
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await;
+
+    Ok(synced)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemPalaceSyncEntry {
+    pub content: String,
+    pub category: String,
+    pub repo_name: String,
+    pub file_paths: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_observation_to_drawer() {
+        let (wing, room) = map_observation_to_drawer("decision", "fury");
+        assert_eq!(wing, "fury");
+        assert_eq!(room, "decisions");
+
+        let (wing, room) = map_observation_to_drawer("error", "");
+        assert_eq!(wing, "_global");
+        assert_eq!(room, "errors");
+
+        let (wing, room) = map_observation_to_drawer("unknown_type", "myrepo");
+        assert_eq!(wing, "myrepo");
+        assert_eq!(room, "general");
+    }
+
+    #[test]
+    fn test_resolve_palace_path_with_configured() {
+        let result = resolve_palace_path(Some("/custom/path"));
+        assert_eq!(result, "/custom/path");
+    }
+
+    #[test]
+    fn test_resolve_palace_path_default() {
+        let result = resolve_palace_path(None);
+        assert!(result.contains(".mempalace"));
+        assert!(result.ends_with("palace"));
+    }
+
+    #[test]
+    fn test_palace_exists_false_for_nonexistent() {
+        assert!(!palace_exists("/nonexistent/path/to/palace"));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -29,4 +29,5 @@ pub mod test_runner;
 pub mod slash_commands;
 pub mod terminal;
 pub mod path_validation;
+pub mod mempalace;
 pub mod worktree;

--- a/src/components/settings/AppSettingsPanel.tsx
+++ b/src/components/settings/AppSettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   Search,
   Blocks,
   ShieldCheck,
+  Brain,
 } from "lucide-react";
 import { useUIStore } from "../../stores/uiStore";
 import { isMac } from "../../lib/keybindings";
@@ -26,6 +27,7 @@ import {
   CodeSearchTab,
   McpTab,
   CodeIntelTab,
+  MemoryTab,
   MigrationTab,
   ExperimentalTab,
   UpdatesTab,
@@ -41,6 +43,7 @@ const NAV_ITEMS: { tab: SettingsTab; label: string; icon: React.ComponentType<{ 
   { tab: "code-search", label: "Code Search", icon: Search },
   { tab: "mcp", label: "MCP Servers", icon: Server },
   { tab: "code-intel", label: "Code Intelligence", icon: Blocks },
+  { tab: "memory", label: "Memory", icon: Brain },
   { tab: "migration", label: "Migration", icon: ArrowLeftRight },
   { tab: "experimental", label: "Experimental", icon: FlaskConical },
   { tab: "updates", label: "Updates", icon: Download },
@@ -137,6 +140,7 @@ export function AppSettingsPanel() {
         {activeTab === "code-search" && <CodeSearchTab />}
         {activeTab === "mcp" && <McpTab />}
         {activeTab === "code-intel" && <CodeIntelTab />}
+        {activeTab === "memory" && <MemoryTab />}
         {activeTab === "migration" && <MigrationTab />}
         {activeTab === "experimental" && <ExperimentalTab />}
         {activeTab === "updates" && <UpdatesTab />}

--- a/src/components/settings/tabs/MemoryTab.tsx
+++ b/src/components/settings/tabs/MemoryTab.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useState, useCallback } from "react";
+import { useSettingsStore } from "../../../stores/settingsStore";
+import type { MemPalaceStatus } from "../../../lib/tauri/bindings.generated";
+
+export function MemoryTab() {
+  const { appSettings, loadSettings, saveSettings } = useSettingsStore();
+  const [saving, setSaving] = useState(false);
+  const [mempalaceStatus, setMempalaceStatus] = useState<MemPalaceStatus | null>(null);
+  const [mempalaceLoading, setMempalaceLoading] = useState(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [migrating, setMigrating] = useState(false);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  const refreshStatus = useCallback(async () => {
+    setMempalaceLoading(true);
+    try {
+      const { commands } = await import("../../../lib/tauri/bindings.generated");
+      const result = await commands.checkMempalaceStatus();
+      if (result.status === "ok") {
+        setMempalaceStatus(result.data);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setMempalaceLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshStatus();
+  }, [refreshStatus]);
+
+  if (!appSettings) {
+    return (
+      <div className="p-4 text-xs" style={{ color: "var(--text-muted)" }}>
+        Loading...
+      </div>
+    );
+  }
+
+  const mpEnabled = appSettings.mempalace?.enabled ?? true;
+
+  const toggleEnabled = async () => {
+    setSaving(true);
+    try {
+      await saveSettings({
+        ...appSettings,
+        mempalace: {
+          ...appSettings.mempalace,
+          enabled: !mpEnabled,
+        },
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleInstall = async () => {
+    setActionMessage("Installing...");
+    try {
+      const { commands } = await import("../../../lib/tauri/bindings.generated");
+      const result = await commands.installMempalacePackage();
+      if (result.status === "ok") {
+        setActionMessage(`Installed: ${result.data}`);
+      } else {
+        setActionMessage(`Error: ${result.error}`);
+      }
+      await refreshStatus();
+    } catch {
+      setActionMessage("Install failed");
+    }
+  };
+
+  const handleInitialize = async () => {
+    setActionMessage("Initializing palace...");
+    try {
+      const { commands } = await import("../../../lib/tauri/bindings.generated");
+      const result = await commands.initializeMempalacePalace();
+      if (result.status === "ok") {
+        setActionMessage("Palace initialized");
+      } else {
+        setActionMessage(`Error: ${result.error}`);
+      }
+      await refreshStatus();
+    } catch {
+      setActionMessage("Initialization failed");
+    }
+  };
+
+  const handleMigrate = async () => {
+    setMigrating(true);
+    setActionMessage("Migrating snapshots...");
+    try {
+      const { commands } = await import("../../../lib/tauri/bindings.generated");
+      const result = await commands.migrateMemoryToMempalace();
+      if (result.status === "ok") {
+        setActionMessage(result.data > 0 ? `Migrated ${result.data} snapshots` : "No snapshots to migrate");
+      } else {
+        setActionMessage(`Error: ${result.error}`);
+      }
+    } catch {
+      setActionMessage("Migration failed");
+    } finally {
+      setMigrating(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="text-[10px]" style={{ color: "var(--text-muted)" }}>
+        Fury remembers context across sessions using a 3-layer memory system: automatic context injection, observation hooks, and semantic search via MemPalace.
+      </div>
+
+      {/* Memory System Toggle */}
+      <Section title="MemPalace">
+        <div className="text-[10px] mb-3" style={{ color: "var(--text-muted)" }}>
+          Semantic memory search powered by ChromaDB. When enabled, agents can search and store memories using vector similarity instead of keyword matching.
+        </div>
+
+        <label className="flex items-center gap-2 text-xs" style={{ color: "var(--text-primary)" }}>
+          <input
+            type="checkbox"
+            checked={mpEnabled}
+            onChange={toggleEnabled}
+            disabled={saving}
+          />
+          Enable MemPalace
+        </label>
+      </Section>
+
+      {/* Status */}
+      {mpEnabled && (
+        <Section title="Status">
+          {mempalaceLoading ? (
+            <div className="text-[10px]" style={{ color: "var(--text-muted)" }}>
+              Checking...
+            </div>
+          ) : mempalaceStatus ? (
+            <div className="space-y-1.5">
+              <StatusRow
+                label="Python"
+                ok={mempalaceStatus.pythonAvailable}
+                detail={mempalaceStatus.pythonCommand}
+              />
+              <StatusRow
+                label="MemPalace"
+                ok={mempalaceStatus.mempalaceInstalled}
+                detail={mempalaceStatus.mempalaceVersion}
+              />
+              <StatusRow
+                label="Palace"
+                ok={mempalaceStatus.palaceInitialized}
+                detail={mempalaceStatus.palacePath}
+              />
+            </div>
+          ) : (
+            <button
+              className="text-[10px] px-2 py-1 rounded"
+              style={{ backgroundColor: "var(--bg-hover)", color: "var(--text-secondary)" }}
+              onClick={refreshStatus}
+            >
+              Check Status
+            </button>
+          )}
+
+          {actionMessage && (
+            <div className="mt-2 text-[10px]" style={{ color: "var(--text-muted)" }}>
+              {actionMessage}
+            </div>
+          )}
+        </Section>
+      )}
+
+      {/* Actions */}
+      {mpEnabled && mempalaceStatus && (
+        <Section title="Setup">
+          <div className="flex flex-wrap gap-2">
+            {!mempalaceStatus.mempalaceInstalled && mempalaceStatus.pythonAvailable && (
+              <ActionButton onClick={handleInstall} disabled={!!actionMessage && actionMessage.endsWith("...")}>
+                Install MemPalace
+              </ActionButton>
+            )}
+
+            {mempalaceStatus.mempalaceInstalled && !mempalaceStatus.palaceInitialized && (
+              <ActionButton onClick={handleInitialize} disabled={!!actionMessage && actionMessage.endsWith("...")}>
+                Initialize Palace
+              </ActionButton>
+            )}
+
+            {mempalaceStatus.mempalaceInstalled && mempalaceStatus.palaceInitialized && (
+              <ActionButton onClick={handleMigrate} disabled={migrating}>
+                {migrating ? "Migrating..." : "Migrate Existing Memory"}
+              </ActionButton>
+            )}
+
+            <ActionButton onClick={refreshStatus} disabled={mempalaceLoading} secondary>
+              Refresh Status
+            </ActionButton>
+          </div>
+        </Section>
+      )}
+
+      {/* Configuration */}
+      {mpEnabled && (
+        <Section title="Configuration">
+          <label className="block mb-2">
+            <span className="text-[10px]" style={{ color: "var(--text-secondary)" }}>
+              Palace Path
+            </span>
+            <input
+              className="mt-1 block w-full rounded px-2 py-1 text-xs"
+              style={{
+                backgroundColor: "var(--bg-primary)",
+                border: "1px solid var(--border)",
+                color: "var(--text-primary)",
+              }}
+              placeholder={mempalaceStatus?.palacePath ?? "~/.mempalace/palace"}
+              value={appSettings.mempalace?.palacePath ?? ""}
+              onChange={async (e) => {
+                const val = e.target.value || null;
+                await saveSettings({
+                  ...appSettings,
+                  mempalace: {
+                    ...appSettings.mempalace,
+                    enabled: mpEnabled,
+                    palacePath: val,
+                  },
+                });
+              }}
+            />
+          </label>
+          <label className="block">
+            <span className="text-[10px]" style={{ color: "var(--text-secondary)" }}>
+              Python Command
+            </span>
+            <input
+              className="mt-1 block w-full rounded px-2 py-1 text-xs"
+              style={{
+                backgroundColor: "var(--bg-primary)",
+                border: "1px solid var(--border)",
+                color: "var(--text-primary)",
+              }}
+              placeholder="python3 (auto-detected)"
+              value={appSettings.mempalace?.pythonCommand ?? ""}
+              onChange={async (e) => {
+                const val = e.target.value || null;
+                await saveSettings({
+                  ...appSettings,
+                  mempalace: {
+                    ...appSettings.mempalace,
+                    enabled: mpEnabled,
+                    pythonCommand: val,
+                  },
+                });
+              }}
+            />
+          </label>
+        </Section>
+      )}
+
+      {/* How It Works */}
+      <Section title="How Memory Works">
+        <div className="space-y-2 text-[10px]" style={{ color: "var(--text-muted)" }}>
+          <div>
+            <strong style={{ color: "var(--text-secondary)" }}>Layer 1 &mdash; Context Injection:</strong>{" "}
+            Compressed memory snapshots are prepended to the system prompt each session (~2-3K tokens).
+          </div>
+          <div>
+            <strong style={{ color: "var(--text-secondary)" }}>Layer 2 &mdash; Observation Hooks:</strong>{" "}
+            Tool results are automatically analyzed to extract decisions, patterns, errors, and file changes. Zero token cost.
+          </div>
+          <div>
+            <strong style={{ color: "var(--text-secondary)" }}>Layer 3 &mdash; Semantic Search:</strong>{" "}
+            {mpEnabled
+              ? "MemPalace provides 19 tools for semantic search, knowledge graph queries, and palace navigation via ChromaDB."
+              : "Basic keyword search via SQLite (enable MemPalace for semantic vector search)."}
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded p-3"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div className="text-xs font-medium mb-2" style={{ color: "var(--text-primary)" }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusRow({ label, ok, detail }: { label: string; ok: boolean; detail: string | null }) {
+  return (
+    <div className="flex items-center gap-2 text-[10px]">
+      <span style={{ color: ok ? "var(--color-success, #22c55e)" : "var(--color-error, #ef4444)" }}>
+        {ok ? "\u2713" : "\u2717"}
+      </span>
+      <span style={{ color: "var(--text-secondary)" }}>{label}</span>
+      {detail && (
+        <span className="truncate" style={{ color: "var(--text-muted)" }}>{detail}</span>
+      )}
+    </div>
+  );
+}
+
+function ActionButton({
+  onClick,
+  disabled,
+  secondary,
+  children,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  secondary?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      className="text-[10px] px-2 py-1 rounded"
+      style={{
+        backgroundColor: secondary ? "var(--bg-hover)" : "var(--accent)",
+        color: secondary ? "var(--text-secondary)" : "var(--text-on-accent, #fff)",
+        opacity: disabled ? 0.5 : 1,
+      }}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/settings/tabs/index.ts
+++ b/src/components/settings/tabs/index.ts
@@ -4,6 +4,7 @@ export { CopilotTab } from "./CopilotTab";
 export { CodeSearchTab } from "./CodeSearchTab";
 export { CodeIntelTab } from "./CodeIntelTab";
 export { McpTab } from "./McpTab";
+export { MemoryTab } from "./MemoryTab";
 export { MigrationTab } from "./MigrationTab";
 export { ExperimentalTab } from "./ExperimentalTab";
 export { UpdatesTab } from "./UpdatesTab";

--- a/src/components/settings/tabs/types.ts
+++ b/src/components/settings/tabs/types.ts
@@ -1,6 +1,6 @@
 import type { ProviderType } from "../../../lib/tauri";
 
-export type SettingsTab = "appearance" | "provider" | "permissions" | "copilot" | "linear" | "azure-devops" | "code-search" | "mcp" | "code-intel" | "migration" | "experimental" | "updates";
+export type SettingsTab = "appearance" | "provider" | "permissions" | "copilot" | "linear" | "azure-devops" | "code-search" | "mcp" | "code-intel" | "memory" | "migration" | "experimental" | "updates";
 
 export const PROVIDER_ENV_HINTS: Record<ProviderType, string[]> = {
   Anthropic: ["ANTHROPIC_API_KEY"],

--- a/src/lib/tauri/bindings.generated.ts
+++ b/src/lib/tauri/bindings.generated.ts
@@ -1815,6 +1815,128 @@ async cancelInlineEdit(editId: string) : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * List memory observations for a workspace.
+ */
+async listMemoryObservations(workspaceId: string, limit: number | null) : Promise<Result<MemoryObservation[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_memory_observations", { workspaceId, limit }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Search memory observations across scopes.
+ */
+async searchMemory(query: string, scope: string, scopeId: string | null, limit: number | null) : Promise<Result<MemoryObservation[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("search_memory", { query, scope, scopeId, limit }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get memory snapshots for a scope.
+ */
+async getMemorySnapshots(scope: string, scopeId: string | null) : Promise<Result<MemorySnapshot[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_memory_snapshots", { scope, scopeId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Build the full memory context for a workspace (for debugging/preview).
+ */
+async getMemoryContext(workspaceId: string, repoId: string) : Promise<Result<string | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_memory_context", { workspaceId, repoId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Save a learning manually (user or agent-initiated).
+ */
+async saveMemoryLearning(request: SaveLearningRequest) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("save_memory_learning", { request }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Clear all memory for a workspace.
+ */
+async clearWorkspaceMemory(workspaceId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clear_workspace_memory", { workspaceId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Prune old observations (called periodically or from settings).
+ */
+async pruneMemoryObservations(olderThanDays: number | null) : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("prune_memory_observations", { olderThanDays }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get the current status of the MemPalace integration.
+ */
+async checkMempalaceStatus() : Promise<Result<MemPalaceStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("check_mempalace_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Initialize a MemPalace palace directory.
+ */
+async initializeMempalacePalace() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("initialize_mempalace_palace") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Install mempalace via pipx, uv, or pip.
+ */
+async installMempalacePackage() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_mempalace_package") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Migrate existing SQLite memory snapshots to MemPalace drawers.
+ * No-op if already migrated.
+ */
+async migrateMemoryToMempalace() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("migrate_memory_to_mempalace") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -1839,7 +1961,7 @@ disablePlanMode: boolean }
 export type AgentStatus = "Idle" | "Running" | "Stopping" | { Error: string }
 export type AgentTurnPayload = { workspaceId: string; durationMs: number; durationApiMs: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number; totalCostUsd: number; numTurns: number; timestamp: number }
 export type AgentType = "claude_code" | "codex_cli"
-export type AppSettings = { agentType?: AgentType; theme: string; provider: ProviderConfig; systemPromptAdditions: string | null; analyticsEnabled: boolean; experimental: ExperimentalSettings; copilot?: CopilotSettings; linear?: LinearSettings; azureDevops?: AzureDevOpsSettings; claudeContext?: ClaudeContextSettings; customThemes?: CustomTheme[] }
+export type AppSettings = { agentType?: AgentType; theme: string; provider: ProviderConfig; systemPromptAdditions: string | null; analyticsEnabled: boolean; experimental: ExperimentalSettings; copilot?: CopilotSettings; linear?: LinearSettings; azureDevops?: AzureDevOpsSettings; claudeContext?: ClaudeContextSettings; mempalace?: MemPalaceSettings; customThemes?: CustomTheme[] }
 export type AzureDevOpsSettings = { pat: string | null; defaultOrg: string | null }
 export type BranchStatus = { branch: string; defaultBranch: string; ahead: number; behind: number; hasUpstream: boolean }
 export type ChatMessage = { id: string; workspaceId: string; role: MessageRole; content: ContentBlock[]; timestamp: string; displayText?: string | null; metadata?: ResponseMetadata | null }
@@ -1933,6 +2055,16 @@ export type LspPlugin = { name: string; scope: string; enabled: boolean; binaryF
 export type LspSuggestion = { pluginName: string; language: string; fileCount: number; binaryName: string; installHint: string }
 export type McpScope = "user" | "project"
 export type McpServer = { name: string; command: string; args: string[]; env: Partial<{ [key in string]: string }>; scope: McpScope }
+export type MemPalaceSettings = { enabled: boolean; palacePath?: string | null; pythonCommand?: string | null }
+export type MemPalaceStatus = { pythonAvailable: boolean; pythonCommand: string | null; mempalaceInstalled: boolean; mempalaceVersion: string | null; palaceInitialized: boolean; palacePath: string }
+/**
+ * A single observation extracted from an agent session via hooks.
+ */
+export type MemoryObservation = { id: string; workspaceId: string; repoId: string; sessionId: string | null; observationType: string; content: string; compressedContent: string | null; sourceTool: string | null; filePaths: string[]; tokensRaw: number | null; tokensCompressed: number | null; createdAt: string; accessedAt: string | null }
+/**
+ * A compressed memory snapshot used for context injection (Layer 1).
+ */
+export type MemorySnapshot = { id: string; scope: string; scopeId: string | null; category: string; content: string; observationIds: string[]; createdAt: string; supersedes: string | null }
 export type MergeResult = { success: boolean; message: string; mergeMethod: string }
 export type MessageRole = "user" | "assistant" | "system"
 export type Notepad = { id: string; title: string; content: string; description: string | null; tags: string[]; pinned: boolean; createdAt: string; updatedAt: string }
@@ -1960,6 +2092,10 @@ export type ReviewInlineComment = { path: string; line: number; body: string }
 export type ReviewsAndComments = { reviews: PrReview[]; reviewComments: PrComment[] }
 export type RunLogsResult = { logs: string; truncated: boolean; taskLogs: TaskLog[] | null }
 export type RunScriptMode = "concurrent" | "nonconcurrent"
+/**
+ * Request to save a learning via the MCP tool or Tauri command.
+ */
+export type SaveLearningRequest = { workspaceId: string; repoId: string; content: string; category: string; scope: string }
 export type SendMessageRequest = { 
 /**
  * Either workspace_id or repo_id must be provided.


### PR DESCRIPTION
## Summary

- Adds a 3-layer memory system (context injection → observation extraction → on-demand MCP tools) that gives AI agents persistent cross-session memory scoped per workspace/repo
- **Layer 1 (Rust):** SQLite-backed storage with memory observations, compressed snapshots, and user-curated learnings injected into agent system prompts via `get_memory_context`
- **Layer 2 (Sidecar):** PostToolUse hook extracts high-signal observations (file edits, test results, errors, git ops) and a rule-based compressor produces concise snapshots — zero API token cost
- **Layer 3 (Sidecar):** In-process MCP server exposes `memory_recall`, `memory_save_learning`, and `memory_search` tools that Claude can call during sessions
- New Tauri commands: `list_memory_observations`, `search_memory`, `get_memory_snapshots`, `get_memory_context`, `save_memory_learning`, `clear_workspace_memory`, `prune_memory_observations`
- DB migration adds `memory_observations`, `memory_snapshots`, and `memory_learnings` tables

## Test plan

- [ ] Verify `cargo check` passes with new commands, models, and DB layer
- [ ] Verify `cargo test export_specta_bindings` regenerates bindings with new memory types
- [ ] Run `npm test` to confirm no frontend regressions
- [ ] Start agent session and confirm memory observations are extracted from tool use events
- [ ] Verify `get_memory_context` returns compressed snapshot text for system prompt injection
- [ ] Test MCP tools (`memory_recall`, `memory_save_learning`) are available to Claude during sessions
- [ ] Confirm memory is scoped per repo — observations from one repo don't leak into another

🤖 Generated with [Claude Code](https://claude.com/claude-code)