### PR TITLE
feat: click-to-open context breakdown popover

### DIFF
--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -723,7 +723,7 @@ export function Composer({ contextId, contextType, agentStatus, onSend, onStop, 
             {/* Right side: Context ring, Plus button, Send button */}
             <div className="flex items-center gap-1.5">
               {sessionStats && sessionStats.totalInputTokens > 0 && (
-                <ContextUsageIndicator stats={sessionStats} />
+                <ContextUsageIndicator stats={sessionStats} workspaceId={workspaceId} />
               )}
               <div className="relative" ref={plusMenuRef}>
                 <button

--- a/src/components/chat/ContextBreakdownPopover.test.tsx
+++ b/src/components/chat/ContextBreakdownPopover.test.tsx
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ContextBreakdownPopover, computeTurnDeltas } from "./ContextBreakdownPopover";
+import { ContextUsageIndicator } from "./ContextUsageIndicator";
+import type { SessionStats } from "../../stores/chatStore";
+import type { ChatMessage } from "../../lib/tauri";
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ data }: { data: Array<{ name: string; value: number }> }) => (
+    <div data-testid="pie">{data.map((d) => <span key={d.name} data-testid={`pie-cell-${d.name}`}>{d.value}</span>)}</div>
+  ),
+  Cell: () => null,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Mock chatStore
+const mockMessages: ChatMessage[] = [];
+vi.mock("../../stores/chatStore", async () => {
+  const actual = await vi.importActual<typeof import("../../stores/chatStore")>("../../stores/chatStore");
+  return {
+    ...actual,
+    useChatStore: (selector: (state: { messages: Record<string, ChatMessage[]> }) => unknown) =>
+      selector({ messages: { "ws-1": mockMessages } }),
+  };
+});
+
+const baseStats: SessionStats = {
+  totalCostUsd: 0.15,
+  totalInputTokens: 80_000,
+  totalOutputTokens: 12_000,
+  numTurns: 5,
+  totalCacheReadTokens: 40_000,
+  totalCacheCreationTokens: 10_000,
+};
+
+function makeAssistantMsg(
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens = 0,
+  costUsd = 0,
+): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: "ws-1",
+    role: "assistant",
+    content: [],
+    timestamp: new Date().toISOString(),
+    metadata: {
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens: 0,
+      totalCostUsd: costUsd,
+      numTurns: 1,
+      durationMs: 1000,
+      durationApiMs: 800,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeTurnDeltas unit tests
+// ---------------------------------------------------------------------------
+
+describe("computeTurnDeltas", () => {
+  it("returns empty array for no messages", () => {
+    expect(computeTurnDeltas([])).toEqual([]);
+  });
+
+  it("returns single delta for one assistant message", () => {
+    const msgs = [makeAssistantMsg(5000, 1000, 2000)];
+    const deltas = computeTurnDeltas(msgs);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toEqual({
+      turn: 1,
+      inputTokens: 5000,
+      outputTokens: 1000,
+      cacheReadTokens: 2000,
+    });
+  });
+
+  it("computes correct deltas between consecutive messages", () => {
+    const msgs = [
+      makeAssistantMsg(5000, 1000, 2000),
+      makeAssistantMsg(12000, 3000, 5000),
+      makeAssistantMsg(20000, 6000, 8000),
+    ];
+    const deltas = computeTurnDeltas(msgs);
+    expect(deltas).toHaveLength(3);
+    expect(deltas[1]).toEqual({
+      turn: 2,
+      inputTokens: 7000,
+      outputTokens: 2000,
+      cacheReadTokens: 3000,
+    });
+    expect(deltas[2]).toEqual({
+      turn: 3,
+      inputTokens: 8000,
+      outputTokens: 3000,
+      cacheReadTokens: 3000,
+    });
+  });
+
+  it("skips non-assistant messages and messages without metadata", () => {
+    const msgs: ChatMessage[] = [
+      { id: "1", workspaceId: "ws-1", role: "user", content: [], timestamp: "" },
+      makeAssistantMsg(5000, 1000),
+      { id: "2", workspaceId: "ws-1", role: "assistant", content: [], timestamp: "" }, // no metadata
+      makeAssistantMsg(10000, 2000),
+    ];
+    const deltas = computeTurnDeltas(msgs);
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0].inputTokens).toBe(5000);
+    expect(deltas[1].inputTokens).toBe(5000); // 10000 - 5000
+  });
+
+  it("clamps negative deltas to zero", () => {
+    // Defensive: if cumulative values somehow decrease
+    const msgs = [
+      makeAssistantMsg(10000, 5000, 3000),
+      makeAssistantMsg(8000, 4000, 2000), // lower than previous (shouldn't happen, but defensive)
+    ];
+    const deltas = computeTurnDeltas(msgs);
+    expect(deltas[1].inputTokens).toBe(0);
+    expect(deltas[1].outputTokens).toBe(0);
+    expect(deltas[1].cacheReadTokens).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContextBreakdownPopover component tests
+// ---------------------------------------------------------------------------
+
+describe("ContextBreakdownPopover", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+    mockMessages.length = 0;
+  });
+
+  it("renders the popover with header and stats", () => {
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    expect(screen.getByText("Context Breakdown")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument(); // turns
+    expect(screen.getByLabelText("Close context breakdown")).toBeInTheDocument();
+  });
+
+  it("shows correct cache hit rate", () => {
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    // 40000 / 80000 = 50%
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("shows 0% cache hit rate when no input tokens", () => {
+    const stats: SessionStats = { ...baseStats, totalInputTokens: 0, totalCacheReadTokens: 0 };
+    render(
+      <ContextBreakdownPopover stats={stats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    // Both the donut center (0% used) and cache hit (0%) show "0%" — just confirm at least one exists
+    expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders donut chart with correct segment values", () => {
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+    // Fresh input = 80000 - 40000 = 40000
+    expect(screen.getByTestId("pie-cell-Fresh input")).toHaveTextContent("40000");
+    // Cached = 40000
+    expect(screen.getByTestId("pie-cell-Cached")).toHaveTextContent("40000");
+    // Remaining = 200000 - 80000 = 120000
+    expect(screen.getByTestId("pie-cell-Available")).toHaveTextContent("120000");
+  });
+
+  it("does not render bar chart with 0 or 1 turn", () => {
+    mockMessages.push(makeAssistantMsg(5000, 1000));
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    expect(screen.queryByTestId("bar-chart")).not.toBeInTheDocument();
+  });
+
+  it("renders bar chart with 2+ turns", () => {
+    mockMessages.push(makeAssistantMsg(5000, 1000));
+    mockMessages.push(makeAssistantMsg(10000, 2000));
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    render(
+      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByLabelText("Close context breakdown"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("handles missing optional cache fields", () => {
+    const stats: SessionStats = {
+      totalCostUsd: 0.05,
+      totalInputTokens: 50_000,
+      totalOutputTokens: 5_000,
+      numTurns: 2,
+    };
+    render(
+      <ContextBreakdownPopover stats={stats} workspaceId="ws-1" onClose={onClose} />,
+    );
+    expect(screen.getByText("0%")).toBeInTheDocument(); // cache hit rate
+    expect(screen.getByText("Context Breakdown")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContextUsageIndicator click-to-open tests
+// ---------------------------------------------------------------------------
+
+describe("ContextUsageIndicator", () => {
+  beforeEach(() => {
+    mockMessages.length = 0;
+  });
+
+  it("shows tooltip on hover when popover is closed", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    const container = screen.getByLabelText(/Context usage/);
+    fireEvent.mouseEnter(container.closest("[class*='relative']")!);
+    expect(screen.getByText(/Context/)).toBeInTheDocument();
+  });
+
+  it("opens popover on click when workspaceId is provided", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+  });
+
+  it("does not open popover when workspaceId is missing", () => {
+    render(<ContextUsageIndicator stats={baseStats} />);
+    // No role="button" when no workspaceId
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("hides tooltip when popover is open", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    const wrapper = screen.getByLabelText(/Context usage/).closest("[class*='relative']")!;
+
+    // Open popover
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+
+    // Hover should not show tooltip
+    fireEvent.mouseEnter(wrapper);
+    // Tooltip would show "Cache read" but popover shows "Cache hit" — check tooltip-specific text is absent
+    // The tooltip has the progress bar div with specific min-width styling
+    const tooltipElements = wrapper.querySelectorAll("[style*='minWidth: 180px']");
+    expect(tooltipElements).toHaveLength(0);
+  });
+
+  it("closes popover on Escape key", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("context-breakdown-popover")).not.toBeInTheDocument();
+  });
+
+  it("closes popover on click outside", () => {
+    render(
+      <div>
+        <ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />
+        <div data-testid="outside">Outside</div>
+      </div>,
+    );
+    fireEvent.click(screen.getByLabelText(/Context usage/));
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByTestId("context-breakdown-popover")).not.toBeInTheDocument();
+  });
+
+  it("toggles popover on repeated clicks", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    const btn = screen.getByRole("button");
+
+    fireEvent.click(btn);
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(screen.queryByTestId("context-breakdown-popover")).not.toBeInTheDocument();
+  });
+
+  it("opens popover with Enter key", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+  });
+
+  it("opens popover with Space key", () => {
+    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    fireEvent.keyDown(screen.getByRole("button"), { key: " " });
+    expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
+  });
+});

--- a/src/components/chat/ContextBreakdownPopover.tsx
+++ b/src/components/chat/ContextBreakdownPopover.tsx
@@ -1,0 +1,302 @@
+import { useState, useEffect, useMemo } from "react";
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { X } from "lucide-react";
+import { formatTokens, formatCost } from "../../lib/format";
+import { useThemeColors } from "../../hooks/useThemeColors";
+import { useChatStore } from "../../stores/chatStore";
+import type { SessionStats } from "../../stores/chatStore";
+import type { ChatMessage } from "../../lib/tauri";
+import { CONTEXT_WINDOW_TOKENS } from "./ContextUsageIndicator";
+
+// ---------------------------------------------------------------------------
+// Per-turn delta computation
+// ---------------------------------------------------------------------------
+
+export interface TurnDelta {
+  turn: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+}
+
+export function computeTurnDeltas(messages: ChatMessage[]): TurnDelta[] {
+  const assistantMsgs = messages.filter(
+    (m) => m.role === "assistant" && m.metadata,
+  );
+
+  return assistantMsgs.map((msg, i) => {
+    const curr = msg.metadata!;
+    const prev = i > 0 ? assistantMsgs[i - 1].metadata! : null;
+    return {
+      turn: i + 1,
+      inputTokens: Math.max(0, (curr.inputTokens ?? 0) - (prev?.inputTokens ?? 0)),
+      outputTokens: Math.max(0, (curr.outputTokens ?? 0) - (prev?.outputTokens ?? 0)),
+      cacheReadTokens: Math.max(0, (curr.cacheReadTokens ?? 0) - (prev?.cacheReadTokens ?? 0)),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Custom bar chart tooltip
+// ---------------------------------------------------------------------------
+
+interface BarTooltipProps {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string }>;
+  label?: number;
+}
+
+function BarTooltipContent({ active, payload, label }: BarTooltipProps) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div
+      className="rounded-md px-2 py-1.5 shadow-lg"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        fontSize: "10px",
+      }}
+    >
+      <div className="mb-1 font-medium" style={{ color: "var(--text-primary)" }}>
+        Turn {label}
+      </div>
+      {payload.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span style={{ color: "var(--text-muted)" }}>{entry.name}</span>
+          <span className="ml-auto" style={{ color: "var(--text-primary)", fontVariantNumeric: "tabular-nums" }}>
+            {formatTokens(entry.value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Donut center label
+// ---------------------------------------------------------------------------
+
+function DonutCenterLabel({ pct }: { pct: number }) {
+  return (
+    <g>
+      <text
+        x={60}
+        y={56}
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{ fontSize: "18px", fontWeight: 700, fill: "var(--text-primary)", fontVariantNumeric: "tabular-nums" }}
+      >
+        {pct.toFixed(0)}%
+      </text>
+      <text
+        x={60}
+        y={74}
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{ fontSize: "10px", fill: "var(--text-muted)" }}
+      >
+        used
+      </text>
+    </g>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Legend dot
+// ---------------------------------------------------------------------------
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="inline-block h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+      <span style={{ color: "var(--text-muted)", fontSize: "10px" }}>{label}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stats grid
+// ---------------------------------------------------------------------------
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span style={{ color: "var(--text-muted)", fontSize: "10px" }}>{label}</span>
+      <span
+        style={{
+          color: "var(--text-primary)",
+          fontSize: "12px",
+          fontWeight: 500,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main popover
+// ---------------------------------------------------------------------------
+
+interface ContextBreakdownPopoverProps {
+  stats: SessionStats;
+  workspaceId: string;
+  onClose: () => void;
+}
+
+export function ContextBreakdownPopover({ stats, workspaceId, onClose }: ContextBreakdownPopoverProps) {
+  const colors = useThemeColors();
+  const messages = useChatStore((s) => s.messages[workspaceId] ?? []);
+  const [visible, setVisible] = useState(false);
+
+  // Fade in on mount
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  // ---- Donut data ----
+  const pct = Math.min(100, (stats.totalInputTokens / CONTEXT_WINDOW_TOKENS) * 100);
+  const cached = stats.totalCacheReadTokens ?? 0;
+  const freshInput = Math.max(0, stats.totalInputTokens - cached);
+  const remaining = Math.max(0, CONTEXT_WINDOW_TOKENS - stats.totalInputTokens);
+
+  const donutData = useMemo(
+    () => [
+      { name: "Fresh input", value: freshInput, color: colors.accent },
+      { name: "Cached", value: cached, color: colors.success },
+      { name: "Available", value: remaining, color: colors.bgHover },
+    ],
+    [freshInput, cached, remaining, colors.accent, colors.success, colors.bgHover],
+  );
+
+  // ---- Per-turn bar data ----
+  const turnDeltas = useMemo(() => {
+    const deltas = computeTurnDeltas(messages);
+    // Show last 15 turns max
+    return deltas.length > 15 ? deltas.slice(-15) : deltas;
+  }, [messages]);
+
+  // ---- Derived stats ----
+  const cacheHitRate =
+    stats.totalInputTokens > 0
+      ? ((cached / stats.totalInputTokens) * 100).toFixed(0)
+      : "0";
+  const cacheCreated = stats.totalCacheCreationTokens ?? 0;
+
+  return (
+    <div
+      data-testid="context-breakdown-popover"
+      className="absolute bottom-full right-0 z-30 mb-2 w-80 rounded-lg shadow-lg overflow-hidden"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(4px)",
+        transition: "opacity 150ms ease-out, transform 150ms ease-out",
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-3 py-2"
+        style={{ borderBottom: "1px solid var(--border)" }}
+      >
+        <span style={{ color: "var(--text-primary)", fontSize: "12px", fontWeight: 600 }}>
+          Context Breakdown
+        </span>
+        <button
+          onClick={onClose}
+          className="flex h-5 w-5 items-center justify-center rounded transition-colors hover:opacity-80 cursor-pointer"
+          style={{ color: "var(--text-muted)" }}
+          aria-label="Close context breakdown"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Donut section */}
+      <div className="flex flex-col items-center px-3 pt-3 pb-2">
+        <PieChart width={120} height={120}>
+          <Pie
+            data={donutData}
+            innerRadius={36}
+            outerRadius={52}
+            dataKey="value"
+            startAngle={90}
+            endAngle={-270}
+            stroke="none"
+            isAnimationActive={false}
+          >
+            {donutData.map((entry, i) => (
+              <Cell key={i} fill={entry.color} />
+            ))}
+          </Pie>
+          <DonutCenterLabel pct={pct} />
+        </PieChart>
+
+        {/* Legend */}
+        <div className="flex items-center gap-3 mt-1">
+          <LegendItem color={colors.accent} label="Fresh input" />
+          <LegendItem color={colors.success} label="Cached" />
+          <LegendItem color={colors.bgHover} label="Available" />
+        </div>
+      </div>
+
+      {/* Per-turn bar chart */}
+      {turnDeltas.length > 1 && (
+        <div
+          className="px-3 pt-2 pb-2"
+          style={{ borderTop: "1px solid var(--border)" }}
+        >
+          <span style={{ color: "var(--text-muted)", fontSize: "10px" }}>
+            Tokens per turn
+          </span>
+          <div className="mt-1" style={{ height: 100 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={turnDeltas} barCategoryGap="20%">
+                <XAxis
+                  dataKey="turn"
+                  tick={{ fill: colors.textMuted, fontSize: 9 }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  tick={{ fill: colors.textMuted, fontSize: 9 }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={(v: number) => formatTokens(v)}
+                  width={36}
+                />
+                <Tooltip content={<BarTooltipContent />} cursor={false} />
+                <Bar dataKey="inputTokens" name="Input" stackId="a" fill={colors.accent} radius={[0, 0, 0, 0]} />
+                <Bar dataKey="outputTokens" name="Output" stackId="a" fill={colors.success} radius={[0, 0, 0, 0]} />
+                <Bar dataKey="cacheReadTokens" name="Cache read" stackId="a" fill={colors.warning} radius={[2, 2, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+
+      {/* Stats grid */}
+      <div
+        className="grid grid-cols-3 gap-x-3 gap-y-2 px-3 py-2.5"
+        style={{ borderTop: "1px solid var(--border)" }}
+      >
+        <StatCell
+          label="Context"
+          value={`${formatTokens(stats.totalInputTokens)} / ${formatTokens(CONTEXT_WINDOW_TOKENS)}`}
+        />
+        <StatCell label="Output" value={formatTokens(stats.totalOutputTokens)} />
+        <StatCell label="Cache hit" value={`${cacheHitRate}%`} />
+        <StatCell label="Cache created" value={formatTokens(cacheCreated)} />
+        <StatCell label="Turns" value={String(stats.numTurns)} />
+        <StatCell label="Cost" value={formatCost(stats.totalCostUsd)} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ContextUsageIndicator.tsx
+++ b/src/components/chat/ContextUsageIndicator.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { formatTokens, formatCost } from "../../lib/format";
 import type { SessionStats } from "../../stores/chatStore";
+import { ContextBreakdownPopover } from "./ContextBreakdownPopover";
 
 export const CONTEXT_WINDOW_TOKENS = 200_000;
 
@@ -59,8 +60,15 @@ function ContextTooltip({ stats, pct, color }: {
   );
 }
 
-export function ContextUsageIndicator({ stats }: { stats: SessionStats }) {
+interface ContextUsageIndicatorProps {
+  stats: SessionStats;
+  workspaceId?: string;
+}
+
+export function ContextUsageIndicator({ stats, workspaceId }: ContextUsageIndicatorProps) {
   const [showTooltip, setShowTooltip] = useState(false);
+  const [showPopover, setShowPopover] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const pct = Math.min(100, (stats.totalInputTokens / CONTEXT_WINDOW_TOKENS) * 100);
   const isWarning = pct >= 75;
@@ -74,16 +82,59 @@ export function ContextUsageIndicator({ stats }: { stats: SessionStats }) {
   const circumference = 2 * Math.PI * radius;
   const dashoffset = circumference * (1 - pct / 100);
 
+  const handleClick = useCallback(() => {
+    if (workspaceId) {
+      setShowPopover((prev) => !prev);
+    }
+  }, [workspaceId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.key === "Enter" || e.key === " ") && workspaceId) {
+        e.preventDefault();
+        setShowPopover((prev) => !prev);
+      }
+    },
+    [workspaceId],
+  );
+
+  // Close on Escape and click-outside
+  useEffect(() => {
+    if (!showPopover) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowPopover(false);
+    };
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowPopover(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showPopover]);
+
   return (
     <div
       className="relative"
-      onMouseEnter={() => setShowTooltip(true)}
+      ref={containerRef}
+      onMouseEnter={() => { if (!showPopover) setShowTooltip(true); }}
       onMouseLeave={() => setShowTooltip(false)}
     >
       <div
-        className="flex items-center justify-center cursor-default"
+        className={`flex items-center justify-center ${workspaceId ? "cursor-pointer" : "cursor-default"}`}
         style={{ width: 24, height: 24 }}
+        role={workspaceId ? "button" : undefined}
+        tabIndex={workspaceId ? 0 : undefined}
         aria-label={`Context usage: ${pct.toFixed(0)}%`}
+        aria-expanded={showPopover}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
       >
         <svg width={24} height={24} viewBox="0 0 24 24">
           <circle
@@ -105,7 +156,14 @@ export function ContextUsageIndicator({ stats }: { stats: SessionStats }) {
           />
         </svg>
       </div>
-      {showTooltip && <ContextTooltip stats={stats} pct={pct} color={color} />}
+      {showTooltip && !showPopover && <ContextTooltip stats={stats} pct={pct} color={color} />}
+      {showPopover && workspaceId && (
+        <ContextBreakdownPopover
+          stats={stats}
+          workspaceId={workspaceId}
+          onClose={() => setShowPopover(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -18,22 +18,7 @@ import {
   computeWorkspaceBreakdown,
   type TimePeriod,
 } from "../../stores/usageStore";
-
-/* v8 ignore start -- SSR/null-safety fallbacks; getPropertyValue always returns a string in DOM */
-function useThemeColors() {
-  const style = typeof document !== "undefined"
-    ? getComputedStyle(document.documentElement)
-    : null;
-  return {
-    accent: style?.getPropertyValue("--accent").trim() ?? "#58a6ff",
-    success: style?.getPropertyValue("--success").trim() ?? "#4ade80",
-    warning: style?.getPropertyValue("--warning").trim() ?? "#facc15",
-    error: style?.getPropertyValue("--error").trim() ?? "#f87171",
-    textMuted: style?.getPropertyValue("--text-muted").trim() ?? "#8b949e",
-    border: style?.getPropertyValue("--border").trim() ?? "#30363d",
-  };
-}
-/* v8 ignore stop */
+import { useThemeColors } from "../../hooks/useThemeColors";
 
 function formatCost(usd: number): string {
   if (usd < 0.01 && usd > 0) return `$${usd.toFixed(4)}`;

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -1,0 +1,20 @@
+/** Shared hook to extract resolved CSS custom property values for chart libraries (e.g. recharts). */
+
+/* v8 ignore start -- SSR/null-safety fallbacks; getPropertyValue always returns a string in DOM */
+export function useThemeColors() {
+  const style = typeof document !== "undefined"
+    ? getComputedStyle(document.documentElement)
+    : null;
+  return {
+    accent: style?.getPropertyValue("--accent").trim() ?? "#58a6ff",
+    success: style?.getPropertyValue("--success").trim() ?? "#4ade80",
+    warning: style?.getPropertyValue("--warning").trim() ?? "#facc15",
+    error: style?.getPropertyValue("--error").trim() ?? "#f87171",
+    textMuted: style?.getPropertyValue("--text-muted").trim() ?? "#8b949e",
+    textPrimary: style?.getPropertyValue("--text-primary").trim() ?? "#e6edf3",
+    border: style?.getPropertyValue("--border").trim() ?? "#30363d",
+    bgHover: style?.getPropertyValue("--bg-hover").trim() ?? "#1c2028",
+    bgSurface: style?.getPropertyValue("--bg-surface").trim() ?? "#161b22",
+  };
+}
+/* v8 ignore stop */


### PR DESCRIPTION
## Summary
- **Context wheel click-to-open**: Clicking the context usage ring in the composer now opens a rich breakdown popover instead of just a hover tooltip
- **Donut chart**: Shows token composition — fresh input (blue), cached (green), and remaining capacity (dark) — with a bold percentage in the center
- **Per-turn stacked bar chart**: Visualizes input/output/cache token usage per conversation turn (computed by diffing cumulative metadata between assistant messages)
- **Stats grid**: 2×3 grid showing context used, output tokens, cache hit rate, cache created, turns, and session cost
- **Shared `useThemeColors` hook**: Extracted from `UsageDashboard` for reuse across chart components
- Hover tooltip still works for quick glance (suppressed when popover is open)
- Keyboard accessible (Enter/Space to toggle, Escape to close) + click-outside dismiss

## Test plan
- [x] 22 new unit tests covering `computeTurnDeltas` math, popover rendering, donut segments, bar chart visibility, click/escape/click-outside/keyboard interactions
- [x] Full test suite passes (4046 tests, 138 files)
- [x] ESLint clean (0 errors)
- [ ] Manual: click context wheel → popover renders with correct token data
- [ ] Manual: verify on 0 turns, 1 turn, 20+ turns
- [ ] Manual: hover tooltip still works when popover is closed
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)