### PR TITLE
fix: keyboard shortcut badge renders as black box on colored buttons

### DIFF
--- a/src/components/chat/ActionBar.tsx
+++ b/src/components/chat/ActionBar.tsx
@@ -39,7 +39,7 @@ export function ActionBarButton({ onClick, icon: Icon, label, color, bgColor, sh
       <Icon className="h-3.5 w-3.5" />
       {label}
       {showShortcut && (
-        <kbd className="ml-1 rounded bg-[var(--bg-hover)] px-1 py-0.5 text-[9px] font-normal" style={{ color: "inherit" }}>
+        <kbd className="ml-1 rounded bg-black/20 px-1 py-0.5 text-[9px] font-normal" style={{ color: "inherit" }}>
           ⌘⇧↵
         </kbd>
       )}


### PR DESCRIPTION
## Summary
- The `<kbd>` shortcut badge on `ActionBarButton` used `bg-[var(--bg-hover)]` — an opaque dark theme color that rendered as a jarring black box on the green "Approve" button
- Replaced with `bg-black/20` (semi-transparent overlay) so the badge adapts naturally to any button background color

## Test plan
- [ ] Open a plan approval prompt and verify the shortcut badge on the green "Approve" button blends naturally (subtle darker green tint, no black box)
- [ ] Verify other `ActionBarButton` instances with `showShortcut` still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)