### PR TITLE
feat: add Ask Chat action to git refresh error toasts

### DIFF
--- a/src/stores/diffStore.test.ts
+++ b/src/stores/diffStore.test.ts
@@ -10,6 +10,10 @@ vi.mock("../lib/tauri", () => ({
 }));
 
 import { useDiffStore } from "./diffStore";
+import { useToastStore } from "./toastStore";
+import { useChatStore } from "./chatStore";
+import { useAgentStore } from "./agentStore";
+import { useWorkspaceStore } from "./workspaceStore";
 import {
   getDiff,
   getFileDiff,
@@ -443,5 +447,66 @@ describe("diffStore - clearPatchPreviews", () => {
     expect(useDiffStore.getState().patchPreviews["ws-2:c.ts"]).toBeTruthy();
     expect(useDiffStore.getState().patchLoading["ws-1:a.ts"]).toBeUndefined();
     expect(useDiffStore.getState().patchLoading["ws-2:c.ts"]).toBe(true);
+  });
+});
+
+describe("diffStore - error toast with Ask Chat", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-1" } as any);
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("shows error toast with Ask Chat action on loadDiff failure", async () => {
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].message).toBe("Error: git error");
+    expect(toasts[0].action).toBeDefined();
+    expect(toasts[0].action!.label).toBe("Ask Chat");
+  });
+
+  it("shows error toast with Ask Chat action on loadRepoDiff failure", async () => {
+    vi.mocked(getRepoDiff).mockRejectedValue(new Error("repo error"));
+    await useDiffStore.getState().loadRepoDiff("repo-1");
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].message).toBe("Error: repo error");
+    expect(toasts[0].action!.label).toBe("Ask Chat");
+  });
+
+  it("sends error to chat when Ask Chat is clicked", async () => {
+    const addUserMessage = vi.fn();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ addUserMessage } as any);
+    useAgentStore.setState({ sendMessage } as any);
+
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    const toast = useToastStore.getState().toasts[0];
+    toast.action!.onClick();
+
+    expect(addUserMessage).toHaveBeenCalledWith(
+      "ws-1",
+      expect.stringContaining("git error"),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      "ws-1",
+      expect.stringContaining("git error"),
+      "workspace",
+    );
+  });
+
+  it("does not show toast when no active workspace", async () => {
+    useWorkspaceStore.setState({ activeWorkspaceId: null } as any);
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 });

--- a/src/stores/diffStore.ts
+++ b/src/stores/diffStore.ts
@@ -10,6 +10,10 @@ import {
   getRepoFileDiff as getRepoFileDiffCmd,
   getRepoFilePatch as getRepoFilePatchCmd,
 } from "../lib/tauri";
+import { useToastStore } from "./toastStore";
+import { useChatStore } from "./chatStore";
+import { useAgentStore } from "./agentStore";
+import { useWorkspaceStore } from "./workspaceStore";
 
 interface DiffStore {
   diffResults: Record<string, DiffResult | null>;
@@ -45,6 +49,23 @@ interface DiffStore {
     filePath: string,
   ) => FilePatchPreview | null;
   clearPatchPreviews: (contextId: string) => void;
+}
+
+function showGitErrorToast(errorMsg: string) {
+  const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+  if (!workspaceId) return;
+  useToastStore.getState().addToast(errorMsg, "error", {
+    action: {
+      label: "Ask Chat",
+      onClick: () => {
+        const prompt = `I got this git error when refreshing changes:\n\n\`\`\`\n${errorMsg}\n\`\`\`\n\nWhat does this mean and how can I fix it?`;
+        useChatStore.getState().addUserMessage(workspaceId, prompt);
+        useAgentStore
+          .getState()
+          .sendMessage(workspaceId, prompt, "workspace");
+      },
+    },
+  });
 }
 
 // Module-level inflight trackers — prevent duplicate concurrent requests
@@ -87,12 +108,14 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
         loading: { ...state.loading, [workspaceId]: false },
       }));
     } catch (e) {
+      const errorMsg = String(e);
       set((state) => ({
         loading: { ...state.loading, [workspaceId]: false },
         error: hasCached
           ? state.error
-          : { ...state.error, [workspaceId]: String(e) },
+          : { ...state.error, [workspaceId]: errorMsg },
       }));
+      showGitErrorToast(errorMsg);
     } finally {
       _inflightDiff.delete(workspaceId);
     }
@@ -125,12 +148,14 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
         loading: { ...state.loading, [repoId]: false },
       }));
     } catch (e) {
+      const errorMsg = String(e);
       set((state) => ({
         loading: { ...state.loading, [repoId]: false },
         error: hasCached
           ? state.error
-          : { ...state.error, [repoId]: String(e) },
+          : { ...state.error, [repoId]: errorMsg },
       }));
+      showGitErrorToast(errorMsg);
     } finally {
       _inflightRepoDiff.delete(repoId);
     }


### PR DESCRIPTION
## Summary
- When git diff refresh fails (`loadDiff` / `loadRepoDiff`), an error toast now appears with an **Ask Chat** button
- Clicking the button sends the error to the active workspace's chat, formatted in a code block, and asks the LLM to diagnose and fix it
- Follows the same pattern as the existing "Fix CI" flow in ChangesPanel

## Files changed
- `src/stores/diffStore.ts` — added `showGitErrorToast()` helper, wired into catch blocks
- `src/stores/diffStore.test.ts` — 4 new tests covering toast creation, click behavior, and edge cases

## Test plan
- [x] `npx vitest run src/stores/diffStore.test.ts` — 51 tests pass
- [ ] Manual: trigger a git error (e.g. corrupt repo path), verify error toast appears with "Ask Chat" button
- [ ] Manual: click "Ask Chat", verify error is sent to chat and LLM responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)