### PR TITLE
feat: file/folder creation in file tree and UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,33 +24,44 @@ Fury lets you manage repositories, workspaces, and AI agent conversations in one
 - **GitHub Copilot** — Inline code completions in the built-in Monaco editor
 - **MCP Servers** — Extend agent capabilities with Model Context Protocol servers
 - **Slash Commands** — Built-in and custom commands for quick agent actions
+- **Web Search** — Search the web directly from the agent chat
 
 ### Workspaces
 - **Multi-workspace** — Run isolated workspaces on separate git branches with full worktree isolation
 - **Create from PR/Issue** — Spin up a workspace directly from a GitHub PR or issue
 - **Pinning & Linking** — Pin important workspaces; link two workspaces for cross-worktree diffs
 - **Sparse Checkout** — Check out only the directories you need for monorepo workflows
+- **Workspace Templates** — Save and reuse workspace configurations
 
 ### Development
 - **File Viewer** — Browse and edit files with Monaco editor and syntax highlighting
+- **Inline Edits** — AI-powered inline code edits within the editor
 - **Diff Viewer** — Review code changes with inline diffs
 - **Merge View** — Sync branches, resolve conflicts, and compare linked workspaces
-- **Integrated Terminal** — Setup, run, and shell terminals powered by xterm
+- **Integrated Terminal** — Setup, run, and shell terminals powered by xterm.js
 - **Dev Containers** — Run agents, terminals, and scripts inside Docker containers with devcontainer CLI or raw Docker support
 - **Scripts** — Configure setup, run, and archive scripts per repository
-- **conductor.json** — Commit team-wide scripts and configuration to your repo
+- **fury.json** — Commit team-wide scripts and configuration to your repo
 - **Todos** — Per-workspace task tracking, injectable into chat via `@todos`
+- **Codebase Search** — Full-text code search powered by Tantivy with tree-sitter syntax awareness
+- **Test Runner** — Run and monitor tests from within the app
+- **Snippets** — Save and reuse code snippets across workspaces
 
 ### Git & GitHub
 - **PR Management** — Create, review, and merge pull requests without leaving the app
+- **AI PR Reviews** — Generate AI-powered pull request reviews
 - **GitHub Actions** — View workflow runs, read logs, and re-run failed jobs
 - **Linear Integration** — Search and link Linear issues to workspaces
 - **Checkpoints** — Save and revert conversation states at any point
+- **Stash Management** — Git stash operations from the UI
+- **Bookmarks** — Bookmark files and locations for quick access
 
 ### App
 - **Command Palette** — Quick actions via `Cmd+K` / `Ctrl+K`
-- **Themes** — Blend, Midnight, and GitHub color schemes
+- **Themes** — Blend, Midnight, and GitHub color schemes (plus custom themes via CSS variables)
+- **Prompt Library** — Save, organize, and reuse prompts
 - **Cursor Migration** — Import MCP servers and rules from Cursor
+- **Export/Import** — Export and import workspace configurations
 - **Auto-updater** — Stay current with GitHub releases
 - **Cross-platform** — macOS (Apple Silicon & Intel), Windows, Linux
 
@@ -58,13 +69,15 @@ Fury lets you manage repositories, workspaces, and AI agent conversations in one
 
 | Layer | Technology |
 |-------|-----------|
-| Frontend | React 19, TypeScript, Tailwind CSS 4, Vite |
+| Frontend | React 19, TypeScript, Tailwind CSS 4, Vite 7 |
 | Desktop | Tauri 2 (Rust) |
 | Editor | Monaco Editor |
 | Terminal | xterm.js |
-| State | Zustand |
-| Database | SQLite (rusqlite) |
-| UI | react-resizable-panels, cmdk |
+| State | Zustand (33 stores) |
+| Database | SQLite (rusqlite, WAL mode) |
+| Search | Tantivy (full-text), tree-sitter (syntax) |
+| IPC | tauri-specta (type-safe, 273 commands) |
+| UI | react-resizable-panels, cmdk, Recharts |
 
 ## Building from Source
 
@@ -85,7 +98,8 @@ npm install
 ### Development
 
 ```bash
-npm run tauri dev
+npm run tauri dev          # Run full app (Rust + Vite dev server)
+npm run dev                # Frontend only (no Rust backend)
 ```
 
 ### Production Build
@@ -99,17 +113,19 @@ Binaries will be in `src-tauri/target/release/bundle/`.
 ### Testing
 
 ```bash
-npm test              # Run unit tests (Vitest)
-npm run test:watch    # Run tests in watch mode
-npm run test:coverage # Run tests with coverage
-npm run test:e2e      # Run end-to-end tests (Playwright)
+npm test                   # Run unit tests (Vitest)
+npm run test:watch         # Run tests in watch mode
+npm run test:coverage      # Run tests with coverage
+npm run test:e2e           # Run end-to-end tests (Playwright)
+npm run test:e2e:headed    # E2E with browser visible
+cd src-tauri && cargo test # Run Rust backend tests
 ```
 
 ### Linting
 
 ```bash
-npm run lint          # Check for lint errors
-npm run lint:fix      # Auto-fix lint errors
+npm run lint               # Check for lint errors
+npm run lint:fix           # Auto-fix lint errors
 ```
 
 ## License

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -26,4 +26,13 @@ if [ -n "$RS_CHANGED" ]; then
     echo "Commit blocked: Rust clippy warnings found. Fix them and try again."
     exit 1
   fi
+
+  echo "Regenerating specta bindings..."
+  cargo test --manifest-path src-tauri/Cargo.toml export_specta_bindings -- --include-ignored --quiet 2>/dev/null
+  if git diff --quiet src/lib/tauri/bindings.generated.ts 2>/dev/null; then
+    : # bindings are up-to-date
+  else
+    echo "Auto-staging updated bindings.generated.ts"
+    git add src/lib/tauri/bindings.generated.ts
+  fi
 fi

--- a/src-tauri/src/commands/file_editor.rs
+++ b/src-tauri/src/commands/file_editor.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::error::AppError;
 use crate::platform;
 use crate::services::diff as diff_svc;
+use crate::services::path_validation::validate_path_within_root;
 use crate::state::AppState;
 use base64::Engine;
 use tauri::State;
@@ -340,6 +341,168 @@ pub async fn save_clipboard_image(data: String, mime_type: String) -> Result<Str
         std::fs::write(&file_path, &bytes)?;
 
         Ok(file_path.to_string_lossy().into_owned())
+    })
+    .await
+    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+}
+
+/// Resolve a relative path within a root directory, creating intermediate
+/// parent directories as needed. Returns the full path after validation.
+fn resolve_and_ensure_parent(root: &Path, relative: &str) -> Result<PathBuf, AppError> {
+    let full = root.join(relative);
+    // Validate the target is within root (handles .. traversal)
+    let validated = validate_path_within_root(&full, root)?;
+    // Create intermediate directories
+    if let Some(parent) = validated.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AppError::GitError(format!("failed to create parent directories: {}", e)))?;
+    }
+    Ok(validated)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn create_workspace_file(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    file_path: String,
+) -> Result<(), AppError> {
+    let ws_id: Uuid = workspace_id
+        .parse()
+        .map_err(|_| AppError::WorkspaceNotFound(Uuid::nil()))?;
+
+    let worktree_path = {
+        let workspaces = state
+            .workspaces
+            .read()
+            .map_err(|_| AppError::GitError("failed to acquire workspace lock".into()))?;
+        let ws = workspaces
+            .get(&ws_id)
+            .ok_or(AppError::WorkspaceNotFound(ws_id))?;
+        ws.worktree_path.clone()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let full_path = resolve_and_ensure_parent(&worktree_path, &file_path)?;
+        if full_path.exists() {
+            return Err(AppError::GitError(format!(
+                "file already exists: {}",
+                file_path
+            )));
+        }
+        std::fs::write(&full_path, "")
+            .map_err(|e| AppError::GitError(format!("failed to create file: {}", e)))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn create_repo_file(
+    state: State<'_, AppState>,
+    repo_id: String,
+    file_path: String,
+) -> Result<(), AppError> {
+    let id: Uuid = repo_id
+        .parse()
+        .map_err(|_| AppError::RepoNotFound(Uuid::nil()))?;
+
+    let repo_path = {
+        let repos = state
+            .repositories
+            .read()
+            .map_err(|_| AppError::GitError("failed to acquire repository lock".into()))?;
+        let repo = repos.get(&id).ok_or(AppError::RepoNotFound(id))?;
+        repo.path.clone()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let full_path = resolve_and_ensure_parent(&repo_path, &file_path)?;
+        if full_path.exists() {
+            return Err(AppError::GitError(format!(
+                "file already exists: {}",
+                file_path
+            )));
+        }
+        std::fs::write(&full_path, "")
+            .map_err(|e| AppError::GitError(format!("failed to create file: {}", e)))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn create_workspace_directory(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    dir_path: String,
+) -> Result<(), AppError> {
+    let ws_id: Uuid = workspace_id
+        .parse()
+        .map_err(|_| AppError::WorkspaceNotFound(Uuid::nil()))?;
+
+    let worktree_path = {
+        let workspaces = state
+            .workspaces
+            .read()
+            .map_err(|_| AppError::GitError("failed to acquire workspace lock".into()))?;
+        let ws = workspaces
+            .get(&ws_id)
+            .ok_or(AppError::WorkspaceNotFound(ws_id))?;
+        ws.worktree_path.clone()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let full_path = validate_path_within_root(&worktree_path.join(&dir_path), &worktree_path)?;
+        if full_path.exists() {
+            return Err(AppError::GitError(format!(
+                "directory already exists: {}",
+                dir_path
+            )));
+        }
+        std::fs::create_dir_all(&full_path)
+            .map_err(|e| AppError::GitError(format!("failed to create directory: {}", e)))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn create_repo_directory(
+    state: State<'_, AppState>,
+    repo_id: String,
+    dir_path: String,
+) -> Result<(), AppError> {
+    let id: Uuid = repo_id
+        .parse()
+        .map_err(|_| AppError::RepoNotFound(Uuid::nil()))?;
+
+    let repo_path = {
+        let repos = state
+            .repositories
+            .read()
+            .map_err(|_| AppError::GitError("failed to acquire repository lock".into()))?;
+        let repo = repos.get(&id).ok_or(AppError::RepoNotFound(id))?;
+        repo.path.clone()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let full_path = validate_path_within_root(&repo_path.join(&dir_path), &repo_path)?;
+        if full_path.exists() {
+            return Err(AppError::GitError(format!(
+                "directory already exists: {}",
+                dir_path
+            )));
+        }
+        std::fs::create_dir_all(&full_path)
+            .map_err(|e| AppError::GitError(format!("failed to create directory: {}", e)))?;
+        Ok(())
     })
     .await
     .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
@@ -776,5 +939,106 @@ mod tests {
         std::fs::create_dir_all(path.join("subdir")).unwrap();
         let result = resolve_new_file_path(&path, "subdir/new-file.txt");
         assert!(result.is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_and_ensure_parent
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_and_ensure_parent_creates_dirs() {
+        let (_dir, path) = test_helpers::create_temp_git_repo();
+        let result = resolve_and_ensure_parent(&path, "newdir/sub/file.txt");
+        assert!(result.is_ok());
+        // Parent directories should have been created
+        assert!(path.join("newdir/sub").exists());
+    }
+
+    #[test]
+    fn test_resolve_and_ensure_parent_traversal_blocked() {
+        let (_dir, path) = test_helpers::create_temp_git_repo();
+        let result = resolve_and_ensure_parent(&path, "../escape");
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // create_workspace_file / create_workspace_directory
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_create_workspace_file() {
+        let (app, _dir, _repo_id, ws_id) = setup_git_state();
+        let state: State<'_, crate::state::AppState> = app.state();
+        let result = create_workspace_file(
+            state,
+            ws_id.to_string(),
+            "new-file.txt".to_string(),
+        )
+        .await;
+        assert!(result.is_ok());
+        // Verify file was created with empty content
+        let state2: State<'_, crate::state::AppState> = app.state();
+        let read = read_workspace_file(state2, ws_id.to_string(), "new-file.txt".to_string()).await;
+        assert!(read.is_ok());
+        assert_eq!(read.unwrap().content, "");
+    }
+
+    #[tokio::test]
+    async fn test_create_workspace_file_nested() {
+        let (app, _dir, _repo_id, ws_id) = setup_git_state();
+        let state: State<'_, crate::state::AppState> = app.state();
+        let result = create_workspace_file(
+            state,
+            ws_id.to_string(),
+            "newdir/sub/file.txt".to_string(),
+        )
+        .await;
+        assert!(result.is_ok());
+        // Read it back
+        let state2: State<'_, crate::state::AppState> = app.state();
+        let read = read_workspace_file(state2, ws_id.to_string(), "newdir/sub/file.txt".to_string()).await;
+        assert!(read.is_ok());
+        assert_eq!(read.unwrap().content, "");
+    }
+
+    #[tokio::test]
+    async fn test_create_workspace_file_already_exists() {
+        let (app, _dir, _repo_id, ws_id) = setup_git_state();
+        // Create the file first
+        let state: State<'_, crate::state::AppState> = app.state();
+        create_workspace_file(state, ws_id.to_string(), "exists.txt".to_string())
+            .await
+            .unwrap();
+        // Try to create again — should fail
+        let state2: State<'_, crate::state::AppState> = app.state();
+        let result = create_workspace_file(state2, ws_id.to_string(), "exists.txt".to_string()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn test_create_workspace_directory() {
+        let (app, _dir, _repo_id, ws_id) = setup_git_state();
+        let state: State<'_, crate::state::AppState> = app.state();
+        let result = create_workspace_directory(
+            state,
+            ws_id.to_string(),
+            "new-dir".to_string(),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_workspace_directory_already_exists() {
+        let (app, _dir, _repo_id, ws_id) = setup_git_state();
+        let state: State<'_, crate::state::AppState> = app.state();
+        create_workspace_directory(state, ws_id.to_string(), "existing-dir".to_string())
+            .await
+            .unwrap();
+        let state2: State<'_, crate::state::AppState> = app.state();
+        let result = create_workspace_directory(state2, ws_id.to_string(), "existing-dir".to_string()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
     }
 }

--- a/src-tauri/src/commands/file_editor.rs
+++ b/src-tauri/src/commands/file_editor.rs
@@ -347,19 +347,22 @@ pub async fn save_clipboard_image(data: String, mime_type: String) -> Result<Str
 }
 
 /// Resolve a relative path within a root directory, creating intermediate
-/// parent directories as needed. Returns the full path after validation.
+/// parent directories as needed. Returns the validated full path. Only creates
+/// intermediate parent directories; the caller is responsible for creating the
+/// final file or directory.
 fn resolve_and_ensure_parent(root: &Path, relative: &str) -> Result<PathBuf, AppError> {
     let full = root.join(relative);
     // Validate the target is within root (handles .. traversal)
     let validated = validate_path_within_root(&full, root)?;
     // Create intermediate directories
     if let Some(parent) = validated.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| AppError::GitError(format!("failed to create parent directories: {}", e)))?;
+        std::fs::create_dir_all(parent)?;
     }
     Ok(validated)
 }
 
+/// Create an empty file inside a workspace worktree. Intermediate parent
+/// directories are created automatically. Fails if the file already exists.
 #[tauri::command]
 #[specta::specta]
 pub async fn create_workspace_file(
@@ -375,7 +378,7 @@ pub async fn create_workspace_file(
         let workspaces = state
             .workspaces
             .read()
-            .map_err(|_| AppError::GitError("failed to acquire workspace lock".into()))?;
+            .map_err(|_| AppError::InternalError("failed to acquire workspace lock".into()))?;
         let ws = workspaces
             .get(&ws_id)
             .ok_or(AppError::WorkspaceNotFound(ws_id))?;
@@ -385,19 +388,20 @@ pub async fn create_workspace_file(
     tokio::task::spawn_blocking(move || {
         let full_path = resolve_and_ensure_parent(&worktree_path, &file_path)?;
         if full_path.exists() {
-            return Err(AppError::GitError(format!(
-                "file already exists: {}",
-                file_path
+            return Err(AppError::IoError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("file already exists: {}", file_path),
             )));
         }
-        std::fs::write(&full_path, "")
-            .map_err(|e| AppError::GitError(format!("failed to create file: {}", e)))?;
+        std::fs::write(&full_path, "")?;
         Ok(())
     })
     .await
-    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+    .map_err(|e| AppError::InternalError(format!("task failed: {}", e)))?
 }
 
+/// Create an empty file inside a repository directory. Intermediate parent
+/// directories are created automatically. Fails if the file already exists.
 #[tauri::command]
 #[specta::specta]
 pub async fn create_repo_file(
@@ -413,7 +417,7 @@ pub async fn create_repo_file(
         let repos = state
             .repositories
             .read()
-            .map_err(|_| AppError::GitError("failed to acquire repository lock".into()))?;
+            .map_err(|_| AppError::InternalError("failed to acquire repository lock".into()))?;
         let repo = repos.get(&id).ok_or(AppError::RepoNotFound(id))?;
         repo.path.clone()
     };
@@ -421,19 +425,19 @@ pub async fn create_repo_file(
     tokio::task::spawn_blocking(move || {
         let full_path = resolve_and_ensure_parent(&repo_path, &file_path)?;
         if full_path.exists() {
-            return Err(AppError::GitError(format!(
-                "file already exists: {}",
-                file_path
+            return Err(AppError::IoError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("file already exists: {}", file_path),
             )));
         }
-        std::fs::write(&full_path, "")
-            .map_err(|e| AppError::GitError(format!("failed to create file: {}", e)))?;
+        std::fs::write(&full_path, "")?;
         Ok(())
     })
     .await
-    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+    .map_err(|e| AppError::InternalError(format!("task failed: {}", e)))?
 }
 
+/// Create a directory inside a workspace worktree. Fails if it already exists.
 #[tauri::command]
 #[specta::specta]
 pub async fn create_workspace_directory(
@@ -449,7 +453,7 @@ pub async fn create_workspace_directory(
         let workspaces = state
             .workspaces
             .read()
-            .map_err(|_| AppError::GitError("failed to acquire workspace lock".into()))?;
+            .map_err(|_| AppError::InternalError("failed to acquire workspace lock".into()))?;
         let ws = workspaces
             .get(&ws_id)
             .ok_or(AppError::WorkspaceNotFound(ws_id))?;
@@ -459,19 +463,19 @@ pub async fn create_workspace_directory(
     tokio::task::spawn_blocking(move || {
         let full_path = validate_path_within_root(&worktree_path.join(&dir_path), &worktree_path)?;
         if full_path.exists() {
-            return Err(AppError::GitError(format!(
-                "directory already exists: {}",
-                dir_path
+            return Err(AppError::IoError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("directory already exists: {}", dir_path),
             )));
         }
-        std::fs::create_dir_all(&full_path)
-            .map_err(|e| AppError::GitError(format!("failed to create directory: {}", e)))?;
+        std::fs::create_dir_all(&full_path)?;
         Ok(())
     })
     .await
-    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+    .map_err(|e| AppError::InternalError(format!("task failed: {}", e)))?
 }
 
+/// Create a directory inside a repository. Fails if it already exists.
 #[tauri::command]
 #[specta::specta]
 pub async fn create_repo_directory(
@@ -487,7 +491,7 @@ pub async fn create_repo_directory(
         let repos = state
             .repositories
             .read()
-            .map_err(|_| AppError::GitError("failed to acquire repository lock".into()))?;
+            .map_err(|_| AppError::InternalError("failed to acquire repository lock".into()))?;
         let repo = repos.get(&id).ok_or(AppError::RepoNotFound(id))?;
         repo.path.clone()
     };
@@ -495,17 +499,16 @@ pub async fn create_repo_directory(
     tokio::task::spawn_blocking(move || {
         let full_path = validate_path_within_root(&repo_path.join(&dir_path), &repo_path)?;
         if full_path.exists() {
-            return Err(AppError::GitError(format!(
-                "directory already exists: {}",
-                dir_path
+            return Err(AppError::IoError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("directory already exists: {}", dir_path),
             )));
         }
-        std::fs::create_dir_all(&full_path)
-            .map_err(|e| AppError::GitError(format!("failed to create directory: {}", e)))?;
+        std::fs::create_dir_all(&full_path)?;
         Ok(())
     })
     .await
-    .map_err(|e| AppError::GitError(format!("task failed: {}", e)))?
+    .map_err(|e| AppError::InternalError(format!("task failed: {}", e)))?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,10 @@ fn specta_builder() -> tauri_specta::Builder {
             commands::file_editor::write_repo_file,
             commands::file_editor::read_file_base64,
             commands::file_editor::save_clipboard_image,
+            commands::file_editor::create_workspace_file,
+            commands::file_editor::create_repo_file,
+            commands::file_editor::create_workspace_directory,
+            commands::file_editor::create_repo_directory,
             // Diff watcher commands
             commands::diff_watcher::start_diff_watcher,
             commands::diff_watcher::stop_diff_watcher,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -917,7 +917,7 @@ describe("App", () => {
       expect(toggleSpy).toHaveBeenCalled();
     });
 
-    it("right-sidebar-bookmarks sets tab and ensures visible", () => {
+    it("right-sidebar-bookmarks switches to files tab and toggles bookmarks", () => {
       setWorkspaceContext();
       const setTabSpy = vi.spyOn(useUIStore.getState(), "setRightSidebarTab");
       const ensureSpy = vi.spyOn(useUIStore.getState(), "ensureRightSidebarVisible");
@@ -925,7 +925,7 @@ describe("App", () => {
       act(() => {
         capturedHandler?.("right-sidebar-bookmarks");
       });
-      expect(setTabSpy).toHaveBeenCalledWith("bookmarks");
+      expect(setTabSpy).toHaveBeenCalledWith("files");
       expect(ensureSpy).toHaveBeenCalled();
     });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,8 +350,11 @@ function App() {
         useNotificationStore.getState().togglePanel();
         break;
       case "right-sidebar-bookmarks":
-        ui.setRightSidebarTab("bookmarks");
+        ui.setRightSidebarTab("files");
         ui.ensureRightSidebarVisible();
+        if (!ui.showBookmarksInFiles) {
+          ui.toggleBookmarksInFiles();
+        }
         break;
       case "view-team":
         ui.openViewTab("team");

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -149,6 +149,18 @@ export function CommandPalette({
                   Open History
                 </PaletteItem>
                 <PaletteItem
+                  onSelect={() => run("view-tests")}
+                  shortcut={shortcutFor("view-tests")}
+                >
+                  Open Test Runner
+                </PaletteItem>
+                <PaletteItem
+                  onSelect={() => run("run-tests")}
+                  shortcut={shortcutFor("run-tests")}
+                >
+                  Run Tests
+                </PaletteItem>
+                <PaletteItem
                   onSelect={() => run("toggle-notifications")}
                   shortcut={shortcutFor("toggle-notifications")}
                 >

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -42,6 +42,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <div
             className="max-w-full truncate text-[10px] font-mono"
             style={{ color: "var(--text-muted)" }}
+            title={this.state.error.message}
           >
             {this.state.error.message}
           </div>

--- a/src/components/activity/AgentActivityPanel.tsx
+++ b/src/components/activity/AgentActivityPanel.tsx
@@ -74,6 +74,7 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
           <span
             className="truncate text-xs font-medium"
             style={{ color: "var(--text-primary)" }}
+            title={entry.toolName}
           >
             {entry.toolName}
           </span>
@@ -87,12 +88,13 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
           <p
             className="mt-0.5 truncate font-mono text-[10px]"
             style={{ color: "var(--text-muted)" }}
+            title={detail}
           >
             {detail}
           </p>
         )}
         {entry.status === "error" && entry.result && (
-          <p className="mt-0.5 truncate text-[10px] text-red-400">
+          <p className="mt-0.5 truncate text-[10px] text-red-400" title={entry.result}>
             {entry.result}
           </p>
         )}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -216,8 +216,12 @@ export function ChatPanel({ contextId, contextType }: Props) {
   }, [contextId, contextType, agentStatus, thinkingEnabled, planEnabled]);
 
   const handleApprovePlan = useCallback(async () => {
-    await handleSend("Approved");
-    setPlanEnabled(false);
+    try {
+      await handleSend("Approved");
+      setPlanEnabled(false);
+    } catch {
+      // If send fails, keep plan mode enabled so user can re-approve
+    }
   }, [handleSend]);
 
   const handleCopyPlan = useCallback(async () => {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -217,6 +217,7 @@ export function ChatPanel({ contextId, contextType }: Props) {
 
   const handleApprovePlan = useCallback(async () => {
     await handleSend("Approved");
+    setPlanEnabled(false);
   }, [handleSend]);
 
   const handleCopyPlan = useCallback(async () => {

--- a/src/components/chat/ChatTOC.tsx
+++ b/src/components/chat/ChatTOC.tsx
@@ -79,7 +79,7 @@ export function ChatTOC({ turns, onClose }: Props) {
               >
                 {idx + 1}.
               </span>
-              <span className="truncate">{preview || "(empty)"}</span>
+              <span className="truncate" title={userText || "(empty)"}>{preview || "(empty)"}</span>
             </button>
           );
         })}

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -723,7 +723,7 @@ export function Composer({ contextId, contextType, agentStatus, onSend, onStop, 
             {/* Right side: Context ring, Plus button, Send button */}
             <div className="flex items-center gap-1.5">
               {sessionStats && sessionStats.totalInputTokens > 0 && (
-                <ContextUsageIndicator stats={sessionStats} workspaceId={workspaceId} />
+                <ContextUsageIndicator stats={sessionStats} contextId={contextId} />
               )}
               <div className="relative" ref={plusMenuRef}>
                 <button

--- a/src/components/chat/ContextBreakdownPopover.test.tsx
+++ b/src/components/chat/ContextBreakdownPopover.test.tsx
@@ -148,7 +148,7 @@ describe("ContextBreakdownPopover", () => {
 
   it("renders the popover with header and stats", () => {
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     expect(screen.getByText("Context Breakdown")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument(); // turns
@@ -157,7 +157,7 @@ describe("ContextBreakdownPopover", () => {
 
   it("shows correct cache hit rate", () => {
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     // 40000 / 80000 = 50%
     expect(screen.getByText("50%")).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe("ContextBreakdownPopover", () => {
   it("shows 0% cache hit rate when no input tokens", () => {
     const stats: SessionStats = { ...baseStats, totalInputTokens: 0, totalCacheReadTokens: 0 };
     render(
-      <ContextBreakdownPopover stats={stats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={stats} contextId="ws-1" onClose={onClose} />,
     );
     // Both the donut center (0% used) and cache hit (0%) show "0%" — just confirm at least one exists
     expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
@@ -174,7 +174,7 @@ describe("ContextBreakdownPopover", () => {
 
   it("renders donut chart with correct segment values", () => {
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
     // Fresh input = 80000 - 40000 = 40000
@@ -188,7 +188,7 @@ describe("ContextBreakdownPopover", () => {
   it("does not render bar chart with 0 or 1 turn", () => {
     mockMessages.push(makeAssistantMsg(5000, 1000));
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     expect(screen.queryByTestId("bar-chart")).not.toBeInTheDocument();
   });
@@ -197,14 +197,14 @@ describe("ContextBreakdownPopover", () => {
     mockMessages.push(makeAssistantMsg(5000, 1000));
     mockMessages.push(makeAssistantMsg(10000, 2000));
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
   });
 
   it("calls onClose when close button clicked", () => {
     render(
-      <ContextBreakdownPopover stats={baseStats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={baseStats} contextId="ws-1" onClose={onClose} />,
     );
     fireEvent.click(screen.getByLabelText("Close context breakdown"));
     expect(onClose).toHaveBeenCalledOnce();
@@ -218,7 +218,7 @@ describe("ContextBreakdownPopover", () => {
       numTurns: 2,
     };
     render(
-      <ContextBreakdownPopover stats={stats} workspaceId="ws-1" onClose={onClose} />,
+      <ContextBreakdownPopover stats={stats} contextId="ws-1" onClose={onClose} />,
     );
     expect(screen.getByText("0%")).toBeInTheDocument(); // cache hit rate
     expect(screen.getByText("Context Breakdown")).toBeInTheDocument();
@@ -235,26 +235,26 @@ describe("ContextUsageIndicator", () => {
   });
 
   it("shows tooltip on hover when popover is closed", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     const container = screen.getByLabelText(/Context usage/);
     fireEvent.mouseEnter(container.closest("[class*='relative']")!);
     expect(screen.getByText(/Context/)).toBeInTheDocument();
   });
 
-  it("opens popover on click when workspaceId is provided", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+  it("opens popover on click when contextId is provided", () => {
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     fireEvent.click(screen.getByRole("button"));
     expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
   });
 
-  it("does not open popover when workspaceId is missing", () => {
+  it("does not open popover when contextId is missing", () => {
     render(<ContextUsageIndicator stats={baseStats} />);
-    // No role="button" when no workspaceId
+    // No role="button" when no contextId
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("hides tooltip when popover is open", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     const wrapper = screen.getByLabelText(/Context usage/).closest("[class*='relative']")!;
 
     // Open popover
@@ -270,7 +270,7 @@ describe("ContextUsageIndicator", () => {
   });
 
   it("closes popover on Escape key", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     fireEvent.click(screen.getByRole("button"));
     expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
 
@@ -281,7 +281,7 @@ describe("ContextUsageIndicator", () => {
   it("closes popover on click outside", () => {
     render(
       <div>
-        <ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />
+        <ContextUsageIndicator stats={baseStats} contextId="ws-1" />
         <div data-testid="outside">Outside</div>
       </div>,
     );
@@ -293,7 +293,7 @@ describe("ContextUsageIndicator", () => {
   });
 
   it("toggles popover on repeated clicks", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     const btn = screen.getByRole("button");
 
     fireEvent.click(btn);
@@ -304,13 +304,13 @@ describe("ContextUsageIndicator", () => {
   });
 
   it("opens popover with Enter key", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
     expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
   });
 
   it("opens popover with Space key", () => {
-    render(<ContextUsageIndicator stats={baseStats} workspaceId="ws-1" />);
+    render(<ContextUsageIndicator stats={baseStats} contextId="ws-1" />);
     fireEvent.keyDown(screen.getByRole("button"), { key: " " });
     expect(screen.getByTestId("context-breakdown-popover")).toBeInTheDocument();
   });

--- a/src/components/chat/ContextBreakdownPopover.tsx
+++ b/src/components/chat/ContextBreakdownPopover.tsx
@@ -146,13 +146,13 @@ function StatCell({ label, value }: { label: string; value: string }) {
 
 interface ContextBreakdownPopoverProps {
   stats: SessionStats;
-  workspaceId: string;
+  contextId: string;
   onClose: () => void;
 }
 
-export function ContextBreakdownPopover({ stats, workspaceId, onClose }: ContextBreakdownPopoverProps) {
+export function ContextBreakdownPopover({ stats, contextId, onClose }: ContextBreakdownPopoverProps) {
   const colors = useThemeColors();
-  const messages = useChatStore((s) => s.messages[workspaceId] ?? []);
+  const messages = useChatStore((s) => s.messages[contextId] ?? []);
   const [visible, setVisible] = useState(false);
 
   // Fade in on mount

--- a/src/components/chat/ContextUsageIndicator.tsx
+++ b/src/components/chat/ContextUsageIndicator.tsx
@@ -62,10 +62,10 @@ function ContextTooltip({ stats, pct, color }: {
 
 interface ContextUsageIndicatorProps {
   stats: SessionStats;
-  workspaceId?: string;
+  contextId?: string;
 }
 
-export function ContextUsageIndicator({ stats, workspaceId }: ContextUsageIndicatorProps) {
+export function ContextUsageIndicator({ stats, contextId }: ContextUsageIndicatorProps) {
   const [showTooltip, setShowTooltip] = useState(false);
   const [showPopover, setShowPopover] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -83,19 +83,19 @@ export function ContextUsageIndicator({ stats, workspaceId }: ContextUsageIndica
   const dashoffset = circumference * (1 - pct / 100);
 
   const handleClick = useCallback(() => {
-    if (workspaceId) {
+    if (contextId) {
       setShowPopover((prev) => !prev);
     }
-  }, [workspaceId]);
+  }, [contextId]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if ((e.key === "Enter" || e.key === " ") && workspaceId) {
+      if ((e.key === "Enter" || e.key === " ") && contextId) {
         e.preventDefault();
         setShowPopover((prev) => !prev);
       }
     },
-    [workspaceId],
+    [contextId],
   );
 
   // Close on Escape and click-outside
@@ -127,10 +127,10 @@ export function ContextUsageIndicator({ stats, workspaceId }: ContextUsageIndica
       onMouseLeave={() => setShowTooltip(false)}
     >
       <div
-        className={`flex items-center justify-center ${workspaceId ? "cursor-pointer" : "cursor-default"}`}
+        className={`flex items-center justify-center ${contextId ? "cursor-pointer" : "cursor-default"}`}
         style={{ width: 24, height: 24 }}
-        role={workspaceId ? "button" : undefined}
-        tabIndex={workspaceId ? 0 : undefined}
+        role={contextId ? "button" : undefined}
+        tabIndex={contextId ? 0 : undefined}
         aria-label={`Context usage: ${pct.toFixed(0)}%`}
         aria-expanded={showPopover}
         onClick={handleClick}
@@ -157,10 +157,10 @@ export function ContextUsageIndicator({ stats, workspaceId }: ContextUsageIndica
         </svg>
       </div>
       {showTooltip && !showPopover && <ContextTooltip stats={stats} pct={pct} color={color} />}
-      {showPopover && workspaceId && (
+      {showPopover && contextId && (
         <ContextBreakdownPopover
           stats={stats}
-          workspaceId={workspaceId}
+          contextId={contextId}
           onClose={() => setShowPopover(false)}
         />
       )}

--- a/src/components/diff/DiffViewer.tsx
+++ b/src/components/diff/DiffViewer.tsx
@@ -18,6 +18,15 @@ function statusLabel(status: FileStatus): string {
   return "?";
 }
 
+function statusTooltip(status: FileStatus): string {
+  if (status === "added") return "Added";
+  if (status === "modified") return "Modified";
+  if (status === "deleted") return "Deleted";
+  if (status === "untracked") return "Untracked";
+  if (typeof status === "object" && "renamed" in status) return "Renamed";
+  return "Unknown";
+}
+
 function statusColor(status: FileStatus): string {
   if (status === "added" || status === "untracked") return "var(--success)";
   if (status === "deleted") return "var(--error)";
@@ -135,10 +144,11 @@ export function DiffViewer({ workspaceId }: Props) {
               <span
                 className="flex-shrink-0 font-mono text-[10px] font-bold"
                 style={{ color: statusColor(file.status) }}
+                title={statusTooltip(file.status)}
               >
                 {statusLabel(file.status)}
               </span>
-              <span className="truncate">{file.path}</span>
+              <span className="truncate" title={file.path}>{file.path}</span>
               <span
                 className="ml-auto flex-shrink-0 text-[10px]"
                 style={{ color: "var(--text-muted)" }}

--- a/src/components/file-viewer/FileTabBar.test.tsx
+++ b/src/components/file-viewer/FileTabBar.test.tsx
@@ -36,6 +36,7 @@ vi.mock("lucide-react", () => ({
   Radar: () => <span data-testid="icon-radar" />,
   SquareTerminal: () => <span data-testid="icon-squareterminal" />,
   Wrench: () => <span data-testid="icon-wrench" />,
+  FlaskConical: ({ className }: { className?: string }) => <span className={className} data-testid="tests-icon" />,
 
 }));
 

--- a/src/components/file-viewer/FileTabBar.tsx
+++ b/src/components/file-viewer/FileTabBar.tsx
@@ -1,4 +1,4 @@
-import { X, Settings, GitMerge, History, FileDiff, Users, Columns2, BarChart3, MessageSquare, Globe } from "lucide-react";
+import { X, Settings, GitMerge, History, FileDiff, Users, Columns2, BarChart3, MessageSquare, Globe, FlaskConical } from "lucide-react";
 import { useFileViewerStore } from "../../stores/fileViewerStore";
 import { useUIStore } from "../../stores/uiStore";
 import type { PaneId } from "../../stores/fileViewerStore";
@@ -9,6 +9,7 @@ const VIEW_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   history: History,
   diff: FileDiff,
   team: Users,
+  tests: FlaskConical,
   usage: BarChart3,
   browser: Globe,
 };

--- a/src/components/history/HistoryView.tsx
+++ b/src/components/history/HistoryView.tsx
@@ -264,6 +264,7 @@ function TimelineEntry({
           backgroundColor: dotColor,
           boxShadow: `0 0 0 2px var(--bg-primary)`,
         }}
+        title={item.kind}
       />
       {/* Content */}
       <div className="min-w-0 flex-1">
@@ -311,7 +312,7 @@ function CommitEntry({
         >
           {data.hash}
         </span>
-        <span className="truncate" style={{ color: "var(--text-primary)" }}>
+        <span className="truncate" style={{ color: "var(--text-primary)" }} title={data.message}>
           {data.message}
         </span>
       </div>
@@ -377,6 +378,7 @@ function ChatEntry({
         <p
           className="mt-1 truncate"
           style={{ color: "var(--text-primary)" }}
+          title={data.text}
         >
           {data.text}
         </p>
@@ -447,6 +449,7 @@ function CheckpointEntry({
         <p
           className="mt-1 truncate"
           style={{ color: "var(--text-primary)" }}
+          title={data.userMessage}
         >
           {data.userMessage}
         </p>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -324,6 +324,7 @@ function RecentRepositories() {
                   <p
                     className="truncate text-sm"
                     style={{ color: "var(--text-muted)" }}
+                    title={repo.path}
                   >
                     {repo.path}
                   </p>

--- a/src/components/layout/RightSidebar.test.tsx
+++ b/src/components/layout/RightSidebar.test.tsx
@@ -103,9 +103,7 @@ vi.mock("../sidebar/ChangesPanel", () => ({
 vi.mock("../sidebar/ChecksPanel", () => ({
   ChecksPanel: () => <div data-testid="checks-panel" />,
 }));
-vi.mock("../sidebar/BookmarksPanel", () => ({
-  BookmarksPanel: () => <div data-testid="bookmarks-panel" />,
-}));
+// BookmarksPanel is now rendered inside FileTreePanel via toggle
 vi.mock("../terminal/TerminalPanel", () => ({
   TerminalPanel: () => <div data-testid="terminal-panel" />,
 }));
@@ -724,15 +722,6 @@ describe("RightSidebar", () => {
       });
 
       expect(runTestsSpy).toHaveBeenCalledWith("r1", "repo", "src/utils.test.ts");
-    });
-  });
-
-  // --- Bookmarks tab ---
-  describe("Bookmarks tab", () => {
-    it("switches to Bookmarks tab and shows BookmarksPanel", () => {
-      render(<RightSidebar context={wsContext} />);
-      fireEvent.click(screen.getByText("Bookmarks"));
-      expect(screen.getByTestId("panel-bookmarks")).toBeInTheDocument();
     });
   });
 

--- a/src/components/layout/RightSidebar.tsx
+++ b/src/components/layout/RightSidebar.tsx
@@ -15,11 +15,12 @@ import { useDiffStore } from "../../stores/diffStore";
 import { FileTreePanel } from "../sidebar/FileTreePanel";
 import { ChangesPanel } from "../sidebar/ChangesPanel";
 import { ChecksPanel } from "../sidebar/ChecksPanel";
-import { BookmarksPanel } from "../sidebar/BookmarksPanel";
+// BookmarksPanel is now rendered inside FileTreePanel via bookmark toggle
 import { TerminalPanel } from "../terminal/TerminalPanel";
 import { RunPanel } from "../terminal/RunPanel";
 import { SetupPanel } from "../terminal/SetupPanel";
 import { AgentActivityPanel } from "../activity/AgentActivityPanel";
+import { TestRunnerPanel } from "../test-runner/TestRunnerPanel";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useFileViewerStore } from "../../stores/fileViewerStore";
 import { useMergeStore } from "../../stores/mergeStore";
@@ -35,13 +36,13 @@ const ALL_TABS: { key: RightSidebarTab; label: string }[] = [
   { key: "files", label: "All files" },
   { key: "changes", label: "Changes" },
   { key: "checks", label: "Checks" },
-  { key: "bookmarks", label: "Bookmarks" },
+  { key: "tests", label: "Tests" },
 ];
 
 const REPO_TABS: { key: RightSidebarTab; label: string }[] = [
   { key: "files", label: "All files" },
   { key: "changes", label: "Changes" },
-  { key: "bookmarks", label: "Bookmarks" },
+  { key: "tests", label: "Tests" },
 ];
 
 const BOTTOM_TABS: { key: BottomTab; label: string }[] = [
@@ -282,10 +283,10 @@ export function RightSidebar({ context }: Props) {
                   </ErrorBoundary>
                 </div>
               )}
-              {activeTab === "bookmarks" && (
-                <div data-testid="panel-bookmarks" className="h-full">
-                  <ErrorBoundary label="bookmarks" resetKey={context.id}>
-                    <BookmarksPanel context={context} />
+              {activeTab === "tests" && (
+                <div data-testid="panel-tests" className="h-full">
+                  <ErrorBoundary label="tests" resetKey={context.id}>
+                    <TestRunnerPanel contextId={context.id} contextType={context.type} />
                   </ErrorBoundary>
                 </div>
               )}

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -212,6 +212,7 @@ export function NotificationPanel() {
                         <span
                           className="h-2 w-2 rounded-full"
                           style={{ backgroundColor: "var(--accent)" }}
+                          title="Unread"
                         />
                       )}
                     </div>
@@ -228,6 +229,7 @@ export function NotificationPanel() {
                         <span
                           className="truncate text-sm font-medium"
                           style={{ color: "var(--text-primary)" }}
+                          title={n.title}
                         >
                           {n.title}
                         </span>
@@ -241,6 +243,7 @@ export function NotificationPanel() {
                       <div
                         className="mt-0.5 truncate text-xs"
                         style={{ color: "var(--text-muted)" }}
+                        title={n.message}
                       >
                         {n.message}
                       </div>

--- a/src/components/settings/RepoSettingsPanel.tsx
+++ b/src/components/settings/RepoSettingsPanel.tsx
@@ -131,7 +131,7 @@ export function RepoSettingsPanel({
             className="text-sm font-semibold min-w-0"
             style={{ color: "var(--text-primary)" }}
           >
-            Settings: <span className="truncate">{repoName}</span>
+            Settings: <span className="truncate" title={repoName}>{repoName}</span>
           </h2>
           <button
             onClick={onClose}
@@ -311,6 +311,7 @@ export function RepoSettingsPanel({
                 <span
                   className="flex-1 truncate font-mono"
                   style={{ color: "var(--text-primary)" }}
+                  title={value}
                 >
                   {value}
                 </span>
@@ -642,6 +643,7 @@ export function RepoSettingsPanel({
                       <div
                         className="text-xs font-medium truncate"
                         style={{ color: "var(--text-primary)" }}
+                        title={t.name}
                       >
                         {t.name}
                       </div>
@@ -649,6 +651,7 @@ export function RepoSettingsPanel({
                         <div
                           className="text-[11px] truncate"
                           style={{ color: "var(--text-muted)" }}
+                          title={t.description}
                         >
                           {t.description}
                         </div>

--- a/src/components/sidebar/CheckRow.tsx
+++ b/src/components/sidebar/CheckRow.tsx
@@ -25,8 +25,9 @@ export function CheckRow({ check }: { check: PrCheck }) {
       <span
         className={`h-2 w-2 flex-shrink-0 rounded-full ${isPending ? "animate-pulse" : ""}`}
         style={{ backgroundColor: dotColor }}
+        title={check.conclusion?.toLowerCase() ?? "pending"}
       />
-      <span className="truncate" style={{ color: "var(--text-primary)" }}>
+      <span className="truncate" style={{ color: "var(--text-primary)" }} title={check.name}>
         {check.name}
       </span>
       {check.detailsUrl && (

--- a/src/components/sidebar/FileTreePanel.test.tsx
+++ b/src/components/sidebar/FileTreePanel.test.tsx
@@ -2,17 +2,42 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { FileTreePanel } from "./FileTreePanel";
 import { useFileTreeStore } from "../../stores/fileTreeStore";
-import { listWorkspaceFiles, listRepoFiles } from "../../lib/tauri";
+import { useUIStore } from "../../stores/uiStore";
+import { useRepositoryStore } from "../../stores/repositoryStore";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import {
+  listWorkspaceFiles,
+  listRepoFiles,
+  createWorkspaceFile,
+  createRepoFile,
+  createWorkspaceDirectory,
+  createRepoDirectory,
+} from "../../lib/tauri";
 
 vi.mock("../../lib/tauri", () => ({
   listWorkspaceFiles: vi.fn().mockResolvedValue([]),
   listRepoFiles: vi.fn().mockResolvedValue([]),
+  initWorkspaceGit: vi.fn().mockResolvedValue(undefined),
+  createWorkspaceFile: vi.fn().mockResolvedValue(undefined),
+  createRepoFile: vi.fn().mockResolvedValue(undefined),
+  createWorkspaceDirectory: vi.fn().mockResolvedValue(undefined),
+  createRepoDirectory: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../icons/FileIcons", () => ({
   getFileIcon: () => () => <span data-testid="file-icon" />,
   FolderIcon: () => <span data-testid="folder-icon" />,
   FolderOpenIcon: () => <span data-testid="folder-open-icon" />,
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./BookmarksPanel", () => ({
+  BookmarksPanel: ({ context }: { context: { id: string; type: string } }) => (
+    <div data-testid="bookmarks-panel">Bookmarks for {context.id}</div>
+  ),
 }));
 
 beforeEach(() => {
@@ -22,10 +47,26 @@ beforeEach(() => {
     loading: {},
     error: {},
   });
+  useRepositoryStore.setState({
+    repositories: [{ id: "repo-1", name: "test-repo", path: "/home/user/test-repo", defaultBranch: "main" }],
+    loading: false,
+    error: null,
+  });
+  useWorkspaceStore.setState({
+    workspaces: [{ id: "ws-1", repoId: "repo-1", name: "test-ws", branch: "main", status: "Active", portBase: 3000, autoCommit: false, pinned: false, createdAt: "", archivedAt: null }],
+  });
+  useUIStore.setState({ showBookmarksInFiles: false });
   vi.clearAllMocks();
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
 });
 
 describe("FileTreePanel", () => {
+  // -----------------------------------------------------------------------
+  // Basic rendering
+  // -----------------------------------------------------------------------
+
   it("shows loading state when loading and no files", () => {
     useFileTreeStore.setState({
       loading: { "ws-1": true },
@@ -134,7 +175,6 @@ describe("FileTreePanel", () => {
       <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
     );
     await screen.findByText("file.ts");
-    // Directories (lib, src) should appear before file.ts
     const buttons = screen.getAllByRole("button");
     const labels = buttons.map(b => b.textContent);
     const libIdx = labels.findIndex(l => l?.includes("lib"));
@@ -150,7 +190,6 @@ describe("FileTreePanel", () => {
       <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
     );
     await screen.findByText("main.ts");
-    // Even if loading is set true now, since files exist, should not show Loading message
     useFileTreeStore.setState({ loading: { "ws-1": true } });
     expect(screen.queryByText("Loading files...")).not.toBeInTheDocument();
   });
@@ -161,9 +200,7 @@ describe("FileTreePanel", () => {
       <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
     );
     const srcDir = await screen.findByText("src");
-    // Collapsed: folder icon
     expect(screen.getByTestId("folder-icon")).toBeInTheDocument();
-    // Expand
     fireEvent.click(srcDir);
     expect(screen.getByTestId("folder-open-icon")).toBeInTheDocument();
   });
@@ -193,117 +230,10 @@ describe("FileTreePanel", () => {
       <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
     );
     const file = await screen.findByText("readme.md");
-    // Should not throw when no callback
     expect(() => fireEvent.click(file)).not.toThrow();
   });
 
-  it("opens context menu on right-click when onRunTestFile is provided", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-  });
-
-  it("does not open context menu on right-click when onRunTestFile is not provided", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    render(
-      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
-  });
-
-  it("does not open context menu when right-clicking a directory", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const srcDir = await screen.findByText("src");
-    fireEvent.contextMenu(srcDir);
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
-  });
-
-  it("calls onRunTestFile and closes context menu when Run Tests is clicked", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    const runButton = screen.getByText("Run Tests");
-    fireEvent.click(runButton);
-    expect(onRunTestFile).toHaveBeenCalledWith("test.spec.ts");
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
-  });
-
-  it("closes context menu when clicking outside", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    // Click outside the context menu
-    fireEvent.mouseDown(document.body);
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
-  });
-
-  it("closes context menu when Escape key is pressed", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
-  });
-
-  it("does not close context menu when clicking inside it", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    const runButton = screen.getByText("Run Tests");
-    // mouseDown inside the menu should not close it
-    fireEvent.mouseDown(runButton);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-  });
-
   it("skips loading when files are already cached", async () => {
-    // Pre-populate the store with files for the context
     const loadFilesSpy = vi.spyOn(useFileTreeStore.getState(), "loadFiles");
     const loadRepoFilesSpy = vi.spyOn(useFileTreeStore.getState(), "loadRepoFiles");
     useFileTreeStore.setState({
@@ -313,15 +243,11 @@ describe("FileTreePanel", () => {
       <FileTreePanel context={{ id: "ws-2", type: "workspace" }} />,
     );
     expect(screen.getByText("cached.ts")).toBeInTheDocument();
-    // Wait for double-rAF to complete by creating our own double-rAF
     await new Promise<void>((resolve) => {
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          resolve();
-        });
+        requestAnimationFrame(() => { resolve(); });
       });
     });
-    // Neither loadFiles nor loadRepoFiles should be called because files are cached
     expect(loadFilesSpy).not.toHaveBeenCalled();
     expect(loadRepoFilesSpy).not.toHaveBeenCalled();
     loadFilesSpy.mockRestore();
@@ -337,42 +263,6 @@ describe("FileTreePanel", () => {
     expect(() => fireEvent.doubleClick(file)).not.toThrow();
   });
 
-  it("does not close context menu on non-Escape key press", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    fireEvent.keyDown(document, { key: "Enter" });
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-  });
-
-  it("cleans up event listeners when context menu unmounts", async () => {
-    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
-    const onRunTestFile = vi.fn();
-    const removeMouseSpy = vi.spyOn(document, "removeEventListener");
-    render(
-      <FileTreePanel
-        context={{ id: "ws-1", type: "workspace" }}
-        onRunTestFile={onRunTestFile}
-      />,
-    );
-    const file = await screen.findByText("test.spec.ts");
-    fireEvent.contextMenu(file);
-    expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    // Close the menu to trigger cleanup
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(removeMouseSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
-    expect(removeMouseSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
-    removeMouseSpy.mockRestore();
-  });
-
   it("cancels animation frames on unmount", async () => {
     const cancelSpy = vi.spyOn(window, "cancelAnimationFrame");
     vi.mocked(listWorkspaceFiles).mockResolvedValue([]);
@@ -382,5 +272,457 @@ describe("FileTreePanel", () => {
     unmount();
     expect(cancelSpy).toHaveBeenCalled();
     cancelSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Header toolbar buttons
+  // -----------------------------------------------------------------------
+
+  it("renders New File and New Folder buttons in the header", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    expect(screen.getByTitle("New File")).toBeInTheDocument();
+    expect(screen.getByTitle("New Folder")).toBeInTheDocument();
+  });
+
+  it("clicking header New File button shows inline input at root", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    fireEvent.click(screen.getByTitle("New File"));
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  it("clicking header New Folder button shows inline input at root", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    fireEvent.click(screen.getByTitle("New Folder"));
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Context menu — basic open/close
+  // -----------------------------------------------------------------------
+
+  it("opens context menu on right-click with New File and New Folder items", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    expect(screen.getByText("New Folder...")).toBeInTheDocument();
+  });
+
+  it("context menu shows Copy Relative Path for files", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("Copy Relative Path")).toBeInTheDocument();
+  });
+
+  it("context menu shows Open File and Open in Editor for files when callbacks provided", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel
+        context={{ id: "ws-1", type: "workspace" }}
+        onFileClick={vi.fn()}
+        onFileDoubleClick={vi.fn()}
+      />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("Open File")).toBeInTheDocument();
+    expect(screen.getByText("Open in Editor")).toBeInTheDocument();
+  });
+
+  it("context menu does not show Open File for directories", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel
+        context={{ id: "ws-1", type: "workspace" }}
+        onFileClick={vi.fn()}
+      />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.contextMenu(srcDir);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    expect(screen.queryByText("Open File")).not.toBeInTheDocument();
+  });
+
+  it("context menu shows Copy Path and Reveal in Finder when repo path available", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("Copy Path")).toBeInTheDocument();
+    expect(screen.getByText("Reveal in Finder")).toBeInTheDocument();
+  });
+
+  it("hides Copy Path and Reveal in Finder when repo path not available", async () => {
+    useRepositoryStore.setState({ repositories: [] });
+    useWorkspaceStore.setState({ workspaces: [] });
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    expect(screen.queryByText("Copy Path")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reveal in Finder")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy Relative Path")).toBeInTheDocument();
+  });
+
+  it("does not show Run Tests in context menu", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel
+        context={{ id: "ws-1", type: "workspace" }}
+        onRunTestFile={vi.fn()}
+      />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
+  });
+
+  it("closes context menu when clicking outside", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("New File...")).not.toBeInTheDocument();
+  });
+
+  it("closes context menu when Escape key is pressed", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByText("New File...")).not.toBeInTheDocument();
+  });
+
+  it("does not close context menu when clicking inside it", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    const newFileBtn = screen.getByText("New File...");
+    fireEvent.mouseDown(newFileBtn);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+  });
+
+  it("does not close context menu on non-Escape key press", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+  });
+
+  it("cleans up event listeners when context menu unmounts", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["test.spec.ts"]);
+    const removeMouseSpy = vi.spyOn(document, "removeEventListener");
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("test.spec.ts");
+    fireEvent.contextMenu(file);
+    expect(screen.getByText("New File...")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(removeMouseSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
+    expect(removeMouseSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    removeMouseSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Context menu — path actions
+  // -----------------------------------------------------------------------
+
+  it("copies relative path to clipboard", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    const file = screen.getByText("main.ts");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("Copy Relative Path"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("src/main.ts");
+  });
+
+  it("copies absolute path to clipboard", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    const file = screen.getByText("main.ts");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("Copy Path"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/home/user/test-repo/src/main.ts");
+  });
+
+  it("calls shell open for Reveal in Finder on files", async () => {
+    const shellMod = await import("@tauri-apps/plugin-shell");
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    const file = screen.getByText("main.ts");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("Reveal in Finder"));
+    await vi.waitFor(() => {
+      expect(shellMod.open).toHaveBeenCalledWith("/home/user/test-repo/src");
+    });
+  });
+
+  it("calls onFileClick from Open File context menu item", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    const onFileClick = vi.fn();
+    render(
+      <FileTreePanel
+        context={{ id: "ws-1", type: "workspace" }}
+        onFileClick={onFileClick}
+      />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("Open File"));
+    expect(onFileClick).toHaveBeenCalledWith("readme.md");
+  });
+
+  it("calls onFileDoubleClick from Open in Editor context menu item", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    const onFileDoubleClick = vi.fn();
+    render(
+      <FileTreePanel
+        context={{ id: "ws-1", type: "workspace" }}
+        onFileDoubleClick={onFileDoubleClick}
+      />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("Open in Editor"));
+    expect(onFileDoubleClick).toHaveBeenCalledWith("readme.md");
+  });
+
+  // -----------------------------------------------------------------------
+  // New File / New Folder context menu + inline input
+  // -----------------------------------------------------------------------
+
+  it("clicking 'New File...' on a directory renders inline input inside it", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    expect(screen.getByText("main.ts")).toBeInTheDocument();
+    fireEvent.contextMenu(srcDir);
+    fireEvent.click(screen.getByText("New File..."));
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  it("clicking 'New File...' on a file targets the parent directory", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    const file = screen.getByText("main.ts");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New File..."));
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  it("clicking 'New File...' on a root-level file shows inline input at root", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New File..."));
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  it("pressing Escape in the inline input clears it without calling any command", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New File..."));
+    const input = screen.getByTestId("inline-new-input");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByTestId("inline-new-input")).not.toBeInTheDocument();
+    expect(createWorkspaceFile).not.toHaveBeenCalled();
+    expect(createRepoFile).not.toHaveBeenCalled();
+  });
+
+  it("pressing Enter calls createWorkspaceFile for workspace context", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    fireEvent.click(srcDir);
+    fireEvent.contextMenu(srcDir);
+    fireEvent.click(screen.getByText("New File..."));
+    const input = screen.getByTestId("inline-new-input");
+    fireEvent.change(input, { target: { value: "newfile.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => {
+      expect(createWorkspaceFile).toHaveBeenCalledWith("ws-1", "src/newfile.ts");
+    });
+  });
+
+  it("pressing Enter calls createRepoFile for repo context", async () => {
+    vi.mocked(listRepoFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "repo-1", type: "repo" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New File..."));
+    const input = screen.getByTestId("inline-new-input");
+    fireEvent.change(input, { target: { value: "newfile.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => {
+      expect(createRepoFile).toHaveBeenCalledWith("repo-1", "newfile.ts");
+    });
+  });
+
+  it("pressing Enter calls createWorkspaceDirectory for 'New Folder...'", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New Folder..."));
+    const input = screen.getByTestId("inline-new-input");
+    fireEvent.change(input, { target: { value: "newdir" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => {
+      expect(createWorkspaceDirectory).toHaveBeenCalledWith("ws-1", "newdir");
+    });
+  });
+
+  it("pressing Enter calls createRepoDirectory for repo context 'New Folder...'", async () => {
+    vi.mocked(listRepoFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "repo-1", type: "repo" }} />,
+    );
+    const file = await screen.findByText("readme.md");
+    fireEvent.contextMenu(file);
+    fireEvent.click(screen.getByText("New Folder..."));
+    const input = screen.getByTestId("inline-new-input");
+    fireEvent.change(input, { target: { value: "newdir" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => {
+      expect(createRepoDirectory).toHaveBeenCalledWith("repo-1", "newdir");
+    });
+  });
+
+  it("target directory is auto-expanded when 'New File...' is clicked on a directory", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["src/main.ts"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    const srcDir = await screen.findByText("src");
+    expect(screen.queryByText("main.ts")).not.toBeInTheDocument();
+    fireEvent.contextMenu(srcDir);
+    fireEvent.click(screen.getByText("New File..."));
+    expect(screen.getByText("main.ts")).toBeInTheDocument();
+    expect(screen.getByTestId("inline-new-input")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Bookmark toggle
+  // -----------------------------------------------------------------------
+
+  it("renders bookmark toggle button in header", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    expect(screen.getByTitle("Show Bookmarks")).toBeInTheDocument();
+  });
+
+  it("clicking bookmark toggle shows BookmarksPanel", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    fireEvent.click(screen.getByTitle("Show Bookmarks"));
+    expect(screen.getByTestId("bookmarks-panel")).toBeInTheDocument();
+    expect(screen.queryByText("readme.md")).not.toBeInTheDocument();
+  });
+
+  it("clicking bookmark toggle again shows file tree", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    // Toggle on
+    fireEvent.click(screen.getByTitle("Show Bookmarks"));
+    expect(screen.getByTestId("bookmarks-panel")).toBeInTheDocument();
+    // Toggle off
+    fireEvent.click(screen.getByTitle("Show Files"));
+    expect(screen.queryByTestId("bookmarks-panel")).not.toBeInTheDocument();
+    expect(screen.getByText("readme.md")).toBeInTheDocument();
+  });
+
+  it("hides New File and New Folder buttons when bookmarks are active", async () => {
+    vi.mocked(listWorkspaceFiles).mockResolvedValue(["readme.md"]);
+    render(
+      <FileTreePanel context={{ id: "ws-1", type: "workspace" }} />,
+    );
+    await screen.findByText("readme.md");
+    expect(screen.getByTitle("New File")).toBeInTheDocument();
+    expect(screen.getByTitle("New Folder")).toBeInTheDocument();
+    // Toggle bookmarks on
+    fireEvent.click(screen.getByTitle("Show Bookmarks"));
+    expect(screen.queryByTitle("New File")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("New Folder")).not.toBeInTheDocument();
   });
 });

--- a/src/components/sidebar/FileTreePanel.tsx
+++ b/src/components/sidebar/FileTreePanel.tsx
@@ -4,6 +4,7 @@ import { useFileTreeStore } from "../../stores/fileTreeStore";
 import { useUIStore } from "../../stores/uiStore";
 import { useRepositoryStore } from "../../stores/repositoryStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
+import { useToastStore } from "../../stores/toastStore";
 import { BookmarksPanel } from "./BookmarksPanel";
 import {
   initWorkspaceGit,
@@ -138,7 +139,11 @@ function InlineNewInput({
         onComplete();
       } catch (err) {
         console.error("Failed to create:", err);
-        onCancel();
+        useToastStore.getState().addToast(
+          `Failed to create ${type}: ${err instanceof Error ? err.message : String(err)}`,
+          "error",
+        );
+        submittedRef.current = false;
       }
     },
     [parentPath, type, context, onComplete, onCancel, onFileClick],
@@ -280,6 +285,7 @@ const TreeItem = memo(function TreeItem({
               onFileDoubleClick={onFileDoubleClick}
               onContextMenu={onContextMenu}
               pendingNewHere={false}
+              pendingNewType={undefined}
               context={context}
             />
           ))}
@@ -390,19 +396,27 @@ function FileTreeContextMenu({
   const absolutePath = repoPath ? `${repoPath}/${filePath}` : null;
 
   const handleCopyPath = () => {
-    if (absolutePath) navigator.clipboard.writeText(absolutePath);
+    if (absolutePath) {
+      navigator.clipboard.writeText(absolutePath).catch((e) => {
+        console.error("Failed to copy path:", e);
+      });
+    }
     onClose();
   };
 
   const handleCopyRelativePath = () => {
-    navigator.clipboard.writeText(filePath);
+    navigator.clipboard.writeText(filePath).catch((e) => {
+      console.error("Failed to copy relative path:", e);
+    });
     onClose();
   };
 
   const handleRevealInFinder = () => {
     if (!absolutePath) { onClose(); return; }
     const dir = isDir ? absolutePath : absolutePath.substring(0, absolutePath.lastIndexOf("/"));
-    import("@tauri-apps/plugin-shell").then(({ open }) => open(dir));
+    import("@tauri-apps/plugin-shell")
+      .then(({ open }) => open(dir))
+      .catch((e) => console.error("Failed to reveal in Finder:", e));
     onClose();
   };
 
@@ -576,7 +590,12 @@ export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTe
               try {
                 await initWorkspaceGit(contextId);
                 useFileTreeStore.getState().loadFiles(contextId);
-              } catch {
+              } catch (err) {
+                console.error("Failed to initialize git:", err);
+                useToastStore.getState().addToast(
+                  `Failed to initialize git repository: ${err instanceof Error ? err.message : String(err)}`,
+                  "error",
+                );
                 setIniting(false);
               }
             }}

--- a/src/components/sidebar/FileTreePanel.tsx
+++ b/src/components/sidebar/FileTreePanel.tsx
@@ -1,7 +1,17 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { GitBranch, Play } from "lucide-react";
+import { GitBranch, FilePlus, FolderPlus, File, Folder, FileText, Pin, Copy, ClipboardCopy, FolderOpen, Bookmark } from "lucide-react";
 import { useFileTreeStore } from "../../stores/fileTreeStore";
-import { initWorkspaceGit } from "../../lib/tauri";
+import { useUIStore } from "../../stores/uiStore";
+import { useRepositoryStore } from "../../stores/repositoryStore";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import { BookmarksPanel } from "./BookmarksPanel";
+import {
+  initWorkspaceGit,
+  createWorkspaceFile,
+  createRepoFile,
+  createWorkspaceDirectory,
+  createRepoDirectory,
+} from "../../lib/tauri";
 import { getFileIcon, FolderIcon, FolderOpenIcon } from "../icons/FileIcons";
 import type { SidebarContext } from "../../App";
 
@@ -65,6 +75,122 @@ function buildTree(paths: string[]): TreeNode[] {
   return root;
 }
 
+function InlineNewInput({
+  depth,
+  type,
+  context,
+  parentPath,
+  onComplete,
+  onCancel,
+  onFileClick,
+}: {
+  depth: number;
+  type: "file" | "directory";
+  context: SidebarContext;
+  parentPath: string;
+  onComplete: () => void;
+  onCancel: () => void;
+  onFileClick?: (filePath: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const submittedRef = useRef(false);
+
+  useEffect(() => {
+    // Auto-focus on mount
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (name: string) => {
+      if (submittedRef.current) return;
+      const trimmed = name.trim();
+      if (!trimmed || trimmed.includes("/") || trimmed.includes("\\")) {
+        onCancel();
+        return;
+      }
+      submittedRef.current = true;
+      const relativePath = parentPath ? `${parentPath}/${trimmed}` : trimmed;
+      try {
+        if (type === "file") {
+          if (context.type === "workspace") {
+            await createWorkspaceFile(context.id, relativePath);
+          } else {
+            await createRepoFile(context.id, relativePath);
+          }
+        } else {
+          if (context.type === "workspace") {
+            await createWorkspaceDirectory(context.id, relativePath);
+          } else {
+            await createRepoDirectory(context.id, relativePath);
+          }
+        }
+        // Refresh file tree
+        const store = useFileTreeStore.getState();
+        if (context.type === "workspace") {
+          store.loadFiles(context.id);
+        } else {
+          store.loadRepoFiles(context.id);
+        }
+        // Open the file if it was a file creation
+        if (type === "file" && onFileClick) {
+          onFileClick(relativePath);
+        }
+        onComplete();
+      } catch (err) {
+        console.error("Failed to create:", err);
+        onCancel();
+      }
+    },
+    [parentPath, type, context, onComplete, onCancel, onFileClick],
+  );
+
+  return (
+    <div
+      className="flex w-full items-center gap-1 py-0.5"
+      style={{ paddingLeft: `${depth * 12 + 8}px` }}
+    >
+      <span className="flex w-4 flex-shrink-0 items-center justify-center">
+        {type === "file" ? (
+          <File className="h-3.5 w-3.5" style={{ color: "var(--text-muted)" }} />
+        ) : (
+          <Folder className="h-3.5 w-3.5" style={{ color: "var(--text-muted)" }} />
+        )}
+      </span>
+      <input
+        ref={inputRef}
+        data-testid="inline-new-input"
+        className="min-w-0 flex-1 rounded-sm px-1 text-sm outline-none"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          color: "var(--text-primary)",
+          border: "1px solid var(--accent)",
+          caretColor: "var(--accent)",
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit((e.target as HTMLInputElement).value);
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        onBlur={(e) => {
+          if (!submittedRef.current) {
+            // If name is non-empty, try to submit; otherwise cancel
+            const val = e.target.value.trim();
+            if (val) {
+              handleSubmit(val);
+            } else {
+              onCancel();
+            }
+          }
+        }}
+      />
+    </div>
+  );
+}
+
 const TreeItem = memo(function TreeItem({
   node,
   depth,
@@ -73,6 +199,11 @@ const TreeItem = memo(function TreeItem({
   onFileClick,
   onFileDoubleClick,
   onContextMenu,
+  pendingNewHere,
+  pendingNewType,
+  onSubmitNew,
+  onCancelNew,
+  context,
 }: {
   node: TreeNode;
   depth: number;
@@ -80,7 +211,12 @@ const TreeItem = memo(function TreeItem({
   onToggle: (path: string) => void;
   onFileClick?: (path: string) => void;
   onFileDoubleClick?: (path: string) => void;
-  onContextMenu?: (path: string, e: React.MouseEvent) => void;
+  onContextMenu?: (path: string, isDir: boolean, e: React.MouseEvent) => void;
+  pendingNewHere: boolean;
+  pendingNewType?: "file" | "directory";
+  onSubmitNew?: () => void;
+  onCancelNew?: () => void;
+  context?: SidebarContext;
 }) {
   const isExpanded = expanded.has(node.path);
 
@@ -100,9 +236,9 @@ const TreeItem = memo(function TreeItem({
           }
         }}
         onContextMenu={(e) => {
-          if (!node.isDir && onContextMenu) {
+          if (onContextMenu) {
             e.preventDefault();
-            onContextMenu(node.path, e);
+            onContextMenu(node.path, node.isDir, e);
           }
         }}
         className="flex w-full items-center gap-1 py-0.5 text-left text-sm hover:bg-[var(--bg-hover)]"
@@ -120,19 +256,35 @@ const TreeItem = memo(function TreeItem({
         </span>
         <span className="truncate">{node.name}</span>
       </button>
-      {node.isDir && isExpanded &&
-        node.children.map((child) => (
-          <TreeItem
-            key={child.path}
-            node={child}
-            depth={depth + 1}
-            expanded={expanded}
-            onToggle={onToggle}
-            onFileClick={onFileClick}
-            onFileDoubleClick={onFileDoubleClick}
-            onContextMenu={onContextMenu}
-          />
-        ))}
+      {node.isDir && isExpanded && (
+        <>
+          {pendingNewHere && pendingNewType && onSubmitNew && onCancelNew && context && (
+            <InlineNewInput
+              depth={depth + 1}
+              type={pendingNewType}
+              context={context}
+              parentPath={node.path}
+              onComplete={onSubmitNew}
+              onCancel={onCancelNew}
+              onFileClick={onFileClick}
+            />
+          )}
+          {node.children.map((child) => (
+            <TreeItem
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              onToggle={onToggle}
+              onFileClick={onFileClick}
+              onFileDoubleClick={onFileDoubleClick}
+              onContextMenu={onContextMenu}
+              pendingNewHere={false}
+              context={context}
+            />
+          ))}
+        </>
+      )}
     </>
   );
 }, /* v8 ignore start -- React.memo comparator is not reliably testable */ (prev, next) => {
@@ -142,6 +294,8 @@ const TreeItem = memo(function TreeItem({
   if (prev.onFileClick !== next.onFileClick) return false;
   if (prev.onFileDoubleClick !== next.onFileDoubleClick) return false;
   if (prev.onContextMenu !== next.onContextMenu) return false;
+  if (prev.pendingNewHere !== next.pendingNewHere) return false;
+  if (prev.pendingNewType !== next.pendingNewType) return false;
   // For files, only the above props matter
   if (!prev.node.isDir) return true;
   // For directories, re-render if our own expansion state changed
@@ -154,16 +308,63 @@ const TreeItem = memo(function TreeItem({
   return prev.expanded === next.expanded;
 } /* v8 ignore stop */);
 
+function getRepoPath(context: SidebarContext): string | null {
+  if (context.type === "repo") {
+    return useRepositoryStore.getState().repositories.find((r) => r.id === context.id)?.path ?? null;
+  }
+  const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === context.id);
+  if (!ws) return null;
+  return useRepositoryStore.getState().repositories.find((r) => r.id === ws.repoId)?.path ?? null;
+}
+
+function ContextMenuItem({
+  icon: Icon,
+  label,
+  onClick,
+  iconColor,
+}: {
+  icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
+  label: string;
+  onClick: () => void;
+  iconColor?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-[var(--bg-hover)]"
+      style={{ color: "var(--text-primary)" }}
+    >
+      <Icon className="h-3 w-3" style={{ color: iconColor ?? "var(--text-muted)" }} />
+      {label}
+    </button>
+  );
+}
+
+function ContextMenuSeparator() {
+  return <div className="my-1" style={{ borderTop: "1px solid var(--border)" }} />;
+}
+
 function FileTreeContextMenu({
   x,
   y,
-  onRunTests,
+  filePath,
+  isDir,
+  context,
+  onNewFile,
+  onNewFolder,
+  onOpenFile,
+  onOpenFilePinned,
   onClose,
 }: {
   x: number;
   y: number;
-  filePath?: string;
-  onRunTests: () => void;
+  filePath: string;
+  isDir: boolean;
+  context: SidebarContext;
+  onNewFile: () => void;
+  onNewFolder: () => void;
+  onOpenFile?: () => void;
+  onOpenFilePinned?: () => void;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -185,10 +386,30 @@ function FileTreeContextMenu({
     };
   }, [onClose]);
 
+  const repoPath = getRepoPath(context);
+  const absolutePath = repoPath ? `${repoPath}/${filePath}` : null;
+
+  const handleCopyPath = () => {
+    if (absolutePath) navigator.clipboard.writeText(absolutePath);
+    onClose();
+  };
+
+  const handleCopyRelativePath = () => {
+    navigator.clipboard.writeText(filePath);
+    onClose();
+  };
+
+  const handleRevealInFinder = () => {
+    if (!absolutePath) { onClose(); return; }
+    const dir = isDir ? absolutePath : absolutePath.substring(0, absolutePath.lastIndexOf("/"));
+    import("@tauri-apps/plugin-shell").then(({ open }) => open(dir));
+    onClose();
+  };
+
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[160px] rounded-md py-1 shadow-lg"
+      className="fixed z-50 min-w-[180px] rounded-md py-1 shadow-lg"
       style={{
         left: x,
         top: y,
@@ -196,22 +417,43 @@ function FileTreeContextMenu({
         border: "1px solid var(--border)",
       }}
     >
-      <button
-        onClick={() => {
-          onRunTests();
-          onClose();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-[var(--bg-hover)]"
-        style={{ color: "var(--text-primary)" }}
-      >
-        <Play className="h-3 w-3" style={{ color: "var(--accent)" }} />
-        Run Tests
-      </button>
+      {/* Create actions */}
+      <ContextMenuItem
+        icon={FilePlus}
+        label="New File..."
+        iconColor="var(--accent)"
+        onClick={() => { onNewFile(); onClose(); }}
+      />
+      <ContextMenuItem
+        icon={FolderPlus}
+        label="New Folder..."
+        iconColor="var(--accent)"
+        onClick={() => { onNewFolder(); onClose(); }}
+      />
+
+      {/* File open actions — files only */}
+      {!isDir && (onOpenFile || onOpenFilePinned) && <ContextMenuSeparator />}
+      {!isDir && onOpenFile && (
+        <ContextMenuItem icon={FileText} label="Open File" onClick={() => { onOpenFile(); onClose(); }} />
+      )}
+      {!isDir && onOpenFilePinned && (
+        <ContextMenuItem icon={Pin} label="Open in Editor" onClick={() => { onOpenFilePinned(); onClose(); }} />
+      )}
+
+      {/* Path actions — files and directories */}
+      <ContextMenuSeparator />
+      {absolutePath && (
+        <ContextMenuItem icon={Copy} label="Copy Path" onClick={handleCopyPath} />
+      )}
+      <ContextMenuItem icon={ClipboardCopy} label="Copy Relative Path" onClick={handleCopyRelativePath} />
+      {absolutePath && (
+        <ContextMenuItem icon={FolderOpen} label="Reveal in Finder" onClick={handleRevealInFinder} />
+      )}
     </div>
   );
 }
 
-export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTestFile }: Props) {
+export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTestFile: _onRunTestFile }: Props) {
   const contextId = context.id;
   const files = useFileTreeStore((s) => s.files[contextId] ?? EMPTY_FILES);
   const expandedDirs = useFileTreeStore(
@@ -219,12 +461,20 @@ export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTe
   );
   const loading = useFileTreeStore((s) => s.loading[contextId] ?? false);
   const error = useFileTreeStore((s) => s.error[contextId] ?? null);
+  const showBookmarks = useUIStore((s) => s.showBookmarksInFiles);
+  const toggleBookmarks = useUIStore((s) => s.toggleBookmarksInFiles);
   const [initing, setIniting] = useState(false);
 
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
     path: string;
+    isDir: boolean;
+  } | null>(null);
+
+  const [pendingNew, setPendingNew] = useState<{
+    parentPath: string; // "" for root
+    type: "file" | "directory";
   } | null>(null);
 
   // Double-rAF: defer file tree loading to Tier 3 so chat data loads first.
@@ -253,11 +503,50 @@ export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTe
   );
 
   const handleContextMenu = useCallback(
-    (path: string, e: React.MouseEvent) => {
-      setContextMenu({ x: e.clientX, y: e.clientY, path });
+    (path: string, isDir: boolean, e: React.MouseEvent) => {
+      setContextMenu({ x: e.clientX, y: e.clientY, path, isDir });
     },
     [],
   );
+
+  const expandAncestors = useCallback(
+    (dirPath: string) => {
+      const store = useFileTreeStore.getState();
+      // Expand all ancestors
+      const parts = dirPath.split("/");
+      for (let i = 1; i <= parts.length; i++) {
+        const ancestor = parts.slice(0, i).join("/");
+        store.expandDir(contextId, ancestor);
+      }
+    },
+    [contextId],
+  );
+
+  const handleNewFile = useCallback(() => {
+    if (!contextMenu) return;
+    const parentPath = contextMenu.isDir
+      ? contextMenu.path
+      : (contextMenu.path.includes("/")
+        ? contextMenu.path.substring(0, contextMenu.path.lastIndexOf("/"))
+        : "");
+    if (parentPath) {
+      expandAncestors(parentPath);
+    }
+    setPendingNew({ parentPath, type: "file" });
+  }, [contextMenu, expandAncestors]);
+
+  const handleNewFolder = useCallback(() => {
+    if (!contextMenu) return;
+    const parentPath = contextMenu.isDir
+      ? contextMenu.path
+      : (contextMenu.path.includes("/")
+        ? contextMenu.path.substring(0, contextMenu.path.lastIndexOf("/"))
+        : "");
+    if (parentPath) {
+      expandAncestors(parentPath);
+    }
+    setPendingNew({ parentPath, type: "directory" });
+  }, [contextMenu, expandAncestors]);
 
   const tree = useMemo(() => buildTree(files), [files]);
 
@@ -298,7 +587,7 @@ export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTe
               opacity: initing ? 0.6 : 1,
             }}
           >
-            {initing ? "Initializing…" : "Initialize Git Repository"}
+            {initing ? "Initializing..." : "Initialize Git Repository"}
           </button>
         </div>
       );
@@ -312,28 +601,97 @@ export function FileTreePanel({ context, onFileClick, onFileDoubleClick, onRunTe
   }
 
   return (
-    <div className="h-full overflow-y-auto py-1">
-      {tree.map((node) => (
-        <TreeItem
-          key={node.path}
-          node={node}
-          depth={0}
-          expanded={expandedDirs}
-          onToggle={handleToggle}
-          onFileClick={onFileClick}
-          onFileDoubleClick={onFileDoubleClick}
-          onContextMenu={onRunTestFile ? handleContextMenu : undefined}
-        />
-      ))}
+    <div className="flex h-full flex-col">
+      {/* Header toolbar */}
+      <div
+        className="flex shrink-0 items-center justify-between px-2 py-1"
+        style={{ borderBottom: "1px solid var(--border)" }}
+      >
+        {/* Left: Bookmark toggle */}
+        <button
+          title={showBookmarks ? "Show Files" : "Show Bookmarks"}
+          aria-label={showBookmarks ? "Show Files" : "Show Bookmarks"}
+          onClick={toggleBookmarks}
+          className="rounded p-1 hover:bg-[var(--bg-hover)]"
+          style={{ color: showBookmarks ? "var(--accent)" : "var(--text-muted)" }}
+        >
+          <Bookmark className="h-3.5 w-3.5" />
+        </button>
+        {/* Right: New File / New Folder (only when showing files) */}
+        <div className="flex items-center gap-0.5">
+          {!showBookmarks && (
+            <>
+              <button
+                title="New File"
+                aria-label="New File"
+                onClick={() => setPendingNew({ parentPath: "", type: "file" })}
+                className="rounded p-1 hover:bg-[var(--bg-hover)]"
+                style={{ color: "var(--text-muted)" }}
+              >
+                <FilePlus className="h-3.5 w-3.5" />
+              </button>
+              <button
+                title="New Folder"
+                aria-label="New Folder"
+                onClick={() => setPendingNew({ parentPath: "", type: "directory" })}
+                className="rounded p-1 hover:bg-[var(--bg-hover)]"
+                style={{ color: "var(--text-muted)" }}
+              >
+                <FolderPlus className="h-3.5 w-3.5" />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
 
-      {contextMenu && onRunTestFile && (
-        <FileTreeContextMenu
-          x={contextMenu.x}
-          y={contextMenu.y}
-          filePath={contextMenu.path}
-          onRunTests={() => onRunTestFile(contextMenu.path)}
-          onClose={() => setContextMenu(null)}
-        />
+      {showBookmarks ? (
+        <BookmarksPanel context={context} />
+      ) : (
+      <div className="flex-1 overflow-y-auto py-1">
+        {pendingNew && pendingNew.parentPath === "" && (
+          <InlineNewInput
+            depth={0}
+            type={pendingNew.type}
+            context={context}
+            parentPath=""
+            onComplete={() => setPendingNew(null)}
+            onCancel={() => setPendingNew(null)}
+            onFileClick={onFileClick}
+          />
+        )}
+        {tree.map((node) => (
+          <TreeItem
+            key={node.path}
+            node={node}
+            depth={0}
+            expanded={expandedDirs}
+            onToggle={handleToggle}
+            onFileClick={onFileClick}
+            onFileDoubleClick={onFileDoubleClick}
+            onContextMenu={handleContextMenu}
+            pendingNewHere={pendingNew?.parentPath === node.path}
+            pendingNewType={pendingNew?.type}
+            onSubmitNew={() => setPendingNew(null)}
+            onCancelNew={() => setPendingNew(null)}
+            context={context}
+          />
+        ))}
+
+        {contextMenu && (
+          <FileTreeContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            filePath={contextMenu.path}
+            isDir={contextMenu.isDir}
+            context={context}
+            onNewFile={handleNewFile}
+            onNewFolder={handleNewFolder}
+            onOpenFile={!contextMenu.isDir && onFileClick ? () => onFileClick(contextMenu.path) : undefined}
+            onOpenFilePinned={!contextMenu.isDir && onFileDoubleClick ? () => onFileDoubleClick(contextMenu.path) : undefined}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
+      </div>
       )}
     </div>
   );

--- a/src/components/sidebar/ReviewRow.tsx
+++ b/src/components/sidebar/ReviewRow.tsx
@@ -31,8 +31,9 @@ export function ReviewRow({ review }: { review: PrReview }) {
         <span
           className="h-2 w-2 flex-shrink-0 rounded-full"
           style={{ backgroundColor: color }}
+          title={reviewStateLabel(review.state)}
         />
-        <span className="truncate font-medium" style={{ color: "var(--text-primary)" }}>
+        <span className="truncate font-medium" style={{ color: "var(--text-primary)" }} title={`@${review.author}`}>
           @{review.author}
         </span>
         <span
@@ -46,6 +47,7 @@ export function ReviewRow({ review }: { review: PrReview }) {
         <p
           className="truncate pl-4 text-xs"
           style={{ color: "var(--text-muted)" }}
+          title={review.body}
         >
           {review.body}
         </p>
@@ -73,6 +75,7 @@ export function ReviewCommentRow({ comment }: { comment: PrComment }) {
           <span
             className="truncate text-xs"
             style={{ color: "var(--accent)" }}
+            title={location}
           >
             {location}
           </span>
@@ -81,6 +84,7 @@ export function ReviewCommentRow({ comment }: { comment: PrComment }) {
       <p
         className="truncate pl-0 text-xs"
         style={{ color: "var(--text-muted)" }}
+        title={comment.body}
       >
         {comment.body}
       </p>

--- a/src/components/sidebar/WorkflowRunRow.tsx
+++ b/src/components/sidebar/WorkflowRunRow.tsx
@@ -102,8 +102,9 @@ export function WorkflowRunRow({
         <span
           className={`h-2 w-2 flex-shrink-0 rounded-full ${inProgress ? "animate-pulse" : ""}`}
           style={{ backgroundColor: color }}
+          title={run.conclusion?.toLowerCase() ?? run.status}
         />
-        <span className="truncate text-left" style={{ color: "var(--text-primary)" }}>
+        <span className="truncate text-left" style={{ color: "var(--text-primary)" }} title={run.workflowName}>
           {run.workflowName}
         </span>
         <span
@@ -127,8 +128,9 @@ export function WorkflowRunRow({
                   <span
                     className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
                     style={{ backgroundColor: jobStatusColor(job) }}
+                    title={job.conclusion?.toLowerCase() ?? job.status}
                   />
-                  <span className="truncate" style={{ color: "var(--text-primary)" }}>
+                  <span className="truncate" style={{ color: "var(--text-primary)" }} title={job.name}>
                     {job.name}
                   </span>
                   <span className="ml-auto flex-shrink-0" style={{ color: jobStatusColor(job) }}>
@@ -150,8 +152,9 @@ export function WorkflowRunRow({
                                   ? "var(--error)"
                                   : "var(--text-muted)",
                           }}
+                          title={step.conclusion ?? "pending"}
                         />
-                        <span className="truncate">{step.name}</span>
+                        <span className="truncate" title={step.name}>{step.name}</span>
                       </div>
                     ))}
                   </div>

--- a/src/components/test-runner/CoverageView.tsx
+++ b/src/components/test-runner/CoverageView.tsx
@@ -25,6 +25,7 @@ export function CoverageView({ coverage }: { coverage: CoverageReport }) {
           <div
             className="h-2 w-24 overflow-hidden rounded-full"
             style={{ backgroundColor: "var(--border)" }}
+            title={`${coverage.totalLinesPct.toFixed(1)}% line coverage`}
           >
             <div
               className="h-full rounded-full"
@@ -67,12 +68,14 @@ export function CoverageView({ coverage }: { coverage: CoverageReport }) {
               <span
                 className="flex-1 truncate"
                 style={{ color: "var(--text-primary)" }}
+                title={file.file}
               >
                 {file.file}
               </span>
               <div
                 className="h-1.5 w-16 overflow-hidden rounded-full"
                 style={{ backgroundColor: "var(--border)" }}
+                title={`${file.linesPct.toFixed(1)}% line coverage`}
               >
                 <div
                   className="h-full rounded-full"

--- a/src/components/test-runner/TestCaseRow.tsx
+++ b/src/components/test-runner/TestCaseRow.tsx
@@ -29,10 +29,12 @@ export function TestCaseRow({
       <span
         className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${isRunning ? "animate-pulse" : ""}`}
         style={{ backgroundColor: color }}
+        title={test.status}
       />
       <span
         className="truncate text-left"
         style={{ color: "var(--text-primary)" }}
+        title={test.name}
       >
         {test.name}
       </span>

--- a/src/components/test-runner/TestSuiteRow.tsx
+++ b/src/components/test-runner/TestSuiteRow.tsx
@@ -61,10 +61,12 @@ export function TestSuiteRow({
           <span
             className={`h-2 w-2 flex-shrink-0 rounded-full ${isRunning ? "animate-pulse" : ""}`}
             style={{ backgroundColor: color }}
+            title={suite.status}
           />
           <span
             className="truncate text-left"
             style={{ color: "var(--text-primary)" }}
+            title={suite.name}
           >
             {suite.name}
           </span>
@@ -73,13 +75,13 @@ export function TestSuiteRow({
             style={{ color: "var(--text-muted)" }}
           >
             {failedCount > 0 && (
-              <span style={{ color: "var(--error)" }}>{failedCount}F </span>
+              <span style={{ color: "var(--error)" }} title={`${failedCount} failed`}>{failedCount}F </span>
             )}
             {passedCount > 0 && (
-              <span style={{ color: "var(--success)" }}>{passedCount}P </span>
+              <span style={{ color: "var(--success)" }} title={`${passedCount} passed`}>{passedCount}P </span>
             )}
             {totalCount > passedCount + failedCount && (
-              <span>{totalCount - passedCount - failedCount}S</span>
+              <span title={`${totalCount - passedCount - failedCount} skipped`}>{totalCount - passedCount - failedCount}S</span>
             )}
           </span>
         </button>

--- a/src/lib/tauri/bindings.generated.ts
+++ b/src/lib/tauri/bindings.generated.ts
@@ -450,6 +450,10 @@ async saveClipboardImage(data: string, mimeType: string) : Promise<Result<string
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Create an empty file inside a workspace worktree. Intermediate parent
+ * directories are created automatically. Fails if the file already exists.
+ */
 async createWorkspaceFile(workspaceId: string, filePath: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_workspace_file", { workspaceId, filePath }) };
@@ -458,6 +462,10 @@ async createWorkspaceFile(workspaceId: string, filePath: string) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Create an empty file inside a repository directory. Intermediate parent
+ * directories are created automatically. Fails if the file already exists.
+ */
 async createRepoFile(repoId: string, filePath: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_repo_file", { repoId, filePath }) };
@@ -466,6 +474,9 @@ async createRepoFile(repoId: string, filePath: string) : Promise<Result<null, st
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Create a directory inside a workspace worktree. Fails if it already exists.
+ */
 async createWorkspaceDirectory(workspaceId: string, dirPath: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_workspace_directory", { workspaceId, dirPath }) };
@@ -474,6 +485,9 @@ async createWorkspaceDirectory(workspaceId: string, dirPath: string) : Promise<R
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Create a directory inside a repository. Fails if it already exists.
+ */
 async createRepoDirectory(repoId: string, dirPath: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_repo_directory", { repoId, dirPath }) };

--- a/src/lib/tauri/bindings.generated.ts
+++ b/src/lib/tauri/bindings.generated.ts
@@ -450,6 +450,38 @@ async saveClipboardImage(data: string, mimeType: string) : Promise<Result<string
     else return { status: "error", error: e  as any };
 }
 },
+async createWorkspaceFile(workspaceId: string, filePath: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_workspace_file", { workspaceId, filePath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async createRepoFile(repoId: string, filePath: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_repo_file", { repoId, filePath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async createWorkspaceDirectory(workspaceId: string, dirPath: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_workspace_directory", { workspaceId, dirPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async createRepoDirectory(repoId: string, dirPath: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_repo_directory", { repoId, dirPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startDiffWatcher(contextId: string, contextType: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_diff_watcher", { contextId, contextType }) };

--- a/src/lib/tauri/files.ts
+++ b/src/lib/tauri/files.ts
@@ -62,3 +62,32 @@ export async function writeRepoFile(
     formatOnSave,
   });
 }
+
+// File/directory creation
+export async function createWorkspaceFile(
+  workspaceId: string,
+  filePath: string,
+): Promise<void> {
+  return invoke<void>("create_workspace_file", { workspaceId, filePath });
+}
+
+export async function createRepoFile(
+  repoId: string,
+  filePath: string,
+): Promise<void> {
+  return invoke<void>("create_repo_file", { repoId, filePath });
+}
+
+export async function createWorkspaceDirectory(
+  workspaceId: string,
+  dirPath: string,
+): Promise<void> {
+  return invoke<void>("create_workspace_directory", { workspaceId, dirPath });
+}
+
+export async function createRepoDirectory(
+  repoId: string,
+  dirPath: string,
+): Promise<void> {
+  return invoke<void>("create_repo_directory", { repoId, dirPath });
+}

--- a/src/stores/diffStore.test.ts
+++ b/src/stores/diffStore.test.ts
@@ -10,6 +10,10 @@ vi.mock("../lib/tauri", () => ({
 }));
 
 import { useDiffStore } from "./diffStore";
+import { useToastStore } from "./toastStore";
+import { useChatStore } from "./chatStore";
+import { useAgentStore } from "./agentStore";
+import { useWorkspaceStore } from "./workspaceStore";
 import {
   getDiff,
   getFileDiff,
@@ -443,5 +447,66 @@ describe("diffStore - clearPatchPreviews", () => {
     expect(useDiffStore.getState().patchPreviews["ws-2:c.ts"]).toBeTruthy();
     expect(useDiffStore.getState().patchLoading["ws-1:a.ts"]).toBeUndefined();
     expect(useDiffStore.getState().patchLoading["ws-2:c.ts"]).toBe(true);
+  });
+});
+
+describe("diffStore - error toast with Ask Chat", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-1" } as any);
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("shows error toast with Ask Chat action on loadDiff failure", async () => {
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].message).toBe("Error: git error");
+    expect(toasts[0].action).toBeDefined();
+    expect(toasts[0].action!.label).toBe("Ask Chat");
+  });
+
+  it("shows error toast with Ask Chat action on loadRepoDiff failure", async () => {
+    vi.mocked(getRepoDiff).mockRejectedValue(new Error("repo error"));
+    await useDiffStore.getState().loadRepoDiff("repo-1");
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].message).toBe("Error: repo error");
+    expect(toasts[0].action!.label).toBe("Ask Chat");
+  });
+
+  it("sends error to chat when Ask Chat is clicked", async () => {
+    const addUserMessage = vi.fn();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ addUserMessage } as any);
+    useAgentStore.setState({ sendMessage } as any);
+
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    const toast = useToastStore.getState().toasts[0];
+    toast.action!.onClick();
+
+    expect(addUserMessage).toHaveBeenCalledWith(
+      "ws-1",
+      expect.stringContaining("git error"),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      "ws-1",
+      expect.stringContaining("git error"),
+      "workspace",
+    );
+  });
+
+  it("does not show toast when no active workspace", async () => {
+    useWorkspaceStore.setState({ activeWorkspaceId: null } as any);
+    vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
+    await useDiffStore.getState().loadDiff("ws-1");
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 });

--- a/src/stores/diffStore.test.ts
+++ b/src/stores/diffStore.test.ts
@@ -477,6 +477,19 @@ describe("diffStore - error toast with Ask Chat", () => {
     expect(toasts[0].type).toBe("error");
     expect(toasts[0].message).toBe("Error: repo error");
     expect(toasts[0].action!.label).toBe("Ask Chat");
+
+    // Verify Ask Chat sends with repo context type
+    const addUserMessage = vi.fn();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ addUserMessage } as any);
+    useAgentStore.setState({ sendMessage } as any);
+
+    toasts[0].action!.onClick();
+    expect(sendMessage).toHaveBeenCalledWith(
+      "repo-1",
+      expect.stringContaining("repo error"),
+      "repo",
+    );
   });
 
   it("sends error to chat when Ask Chat is clicked", async () => {
@@ -502,11 +515,15 @@ describe("diffStore - error toast with Ask Chat", () => {
     );
   });
 
-  it("does not show toast when no active workspace", async () => {
+  it("shows toast without Ask Chat action when no active workspace and no contextId", async () => {
     useWorkspaceStore.setState({ activeWorkspaceId: null } as any);
     vi.mocked(getDiff).mockRejectedValue(new Error("git error"));
     await useDiffStore.getState().loadDiff("ws-1");
 
-    expect(useToastStore.getState().toasts).toHaveLength(0);
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe("error");
+    // Still has action because contextId is passed directly from loadDiff
+    expect(toasts[0].action).toBeDefined();
   });
 });

--- a/src/stores/diffStore.ts
+++ b/src/stores/diffStore.ts
@@ -10,6 +10,10 @@ import {
   getRepoFileDiff as getRepoFileDiffCmd,
   getRepoFilePatch as getRepoFilePatchCmd,
 } from "../lib/tauri";
+import { useToastStore } from "./toastStore";
+import { useChatStore } from "./chatStore";
+import { useAgentStore } from "./agentStore";
+import { useWorkspaceStore } from "./workspaceStore";
 
 interface DiffStore {
   diffResults: Record<string, DiffResult | null>;
@@ -45,6 +49,23 @@ interface DiffStore {
     filePath: string,
   ) => FilePatchPreview | null;
   clearPatchPreviews: (contextId: string) => void;
+}
+
+function showGitErrorToast(errorMsg: string) {
+  const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+  if (!workspaceId) return;
+  useToastStore.getState().addToast(errorMsg, "error", {
+    action: {
+      label: "Ask Chat",
+      onClick: () => {
+        const prompt = `I got this git error when refreshing changes:\n\n\`\`\`\n${errorMsg}\n\`\`\`\n\nWhat does this mean and how can I fix it?`;
+        useChatStore.getState().addUserMessage(workspaceId, prompt);
+        useAgentStore
+          .getState()
+          .sendMessage(workspaceId, prompt, "workspace");
+      },
+    },
+  });
 }
 
 // Module-level inflight trackers — prevent duplicate concurrent requests
@@ -87,12 +108,14 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
         loading: { ...state.loading, [workspaceId]: false },
       }));
     } catch (e) {
+      const errorMsg = String(e);
       set((state) => ({
         loading: { ...state.loading, [workspaceId]: false },
         error: hasCached
           ? state.error
-          : { ...state.error, [workspaceId]: String(e) },
+          : { ...state.error, [workspaceId]: errorMsg },
       }));
+      showGitErrorToast(errorMsg);
     } finally {
       _inflightDiff.delete(workspaceId);
     }
@@ -125,12 +148,14 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
         loading: { ...state.loading, [repoId]: false },
       }));
     } catch (e) {
+      const errorMsg = String(e);
       set((state) => ({
         loading: { ...state.loading, [repoId]: false },
         error: hasCached
           ? state.error
-          : { ...state.error, [repoId]: String(e) },
+          : { ...state.error, [repoId]: errorMsg },
       }));
+      showGitErrorToast(errorMsg);
     } finally {
       _inflightRepoDiff.delete(repoId);
     }

--- a/src/stores/diffStore.ts
+++ b/src/stores/diffStore.ts
@@ -51,20 +51,30 @@ interface DiffStore {
   clearPatchPreviews: (contextId: string) => void;
 }
 
-function showGitErrorToast(errorMsg: string) {
-  const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
-  if (!workspaceId) return;
+/** Show an error toast with an "Ask Chat" action that pre-populates a chat
+ *  message asking the AI agent to diagnose the git error. */
+function showGitErrorToast(
+  errorMsg: string,
+  contextId?: string,
+  contextType: "workspace" | "repo" = "workspace",
+) {
+  const resolvedId =
+    contextId ?? useWorkspaceStore.getState().activeWorkspaceId;
   useToastStore.getState().addToast(errorMsg, "error", {
-    action: {
-      label: "Ask Chat",
-      onClick: () => {
-        const prompt = `I got this git error when refreshing changes:\n\n\`\`\`\n${errorMsg}\n\`\`\`\n\nWhat does this mean and how can I fix it?`;
-        useChatStore.getState().addUserMessage(workspaceId, prompt);
-        useAgentStore
-          .getState()
-          .sendMessage(workspaceId, prompt, "workspace");
-      },
-    },
+    action: resolvedId
+      ? {
+          label: "Ask Chat",
+          onClick: () => {
+            const prompt = `I got this git error when refreshing changes:\n\n\`\`\`\n${errorMsg}\n\`\`\`\n\nWhat does this mean and how can I fix it?`;
+            useChatStore
+              .getState()
+              .addUserMessage(resolvedId, prompt);
+            useAgentStore
+              .getState()
+              .sendMessage(resolvedId, prompt, contextType);
+          },
+        }
+      : undefined,
   });
 }
 
@@ -115,7 +125,7 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
           ? state.error
           : { ...state.error, [workspaceId]: errorMsg },
       }));
-      showGitErrorToast(errorMsg);
+      showGitErrorToast(errorMsg, workspaceId, "workspace");
     } finally {
       _inflightDiff.delete(workspaceId);
     }
@@ -155,7 +165,7 @@ export const useDiffStore = create<DiffStore>((set, get) => ({
           ? state.error
           : { ...state.error, [repoId]: errorMsg },
       }));
-      showGitErrorToast(errorMsg);
+      showGitErrorToast(errorMsg, repoId, "repo");
     } finally {
       _inflightRepoDiff.delete(repoId);
     }

--- a/src/stores/fileTreeStore.ts
+++ b/src/stores/fileTreeStore.ts
@@ -10,6 +10,7 @@ interface FileTreeStore {
   loadFiles: (workspaceId: string) => Promise<void>;
   loadRepoFiles: (repoId: string) => Promise<void>;
   toggleDir: (contextId: string, dir: string) => void;
+  expandDir: (contextId: string, dir: string) => void;
 }
 
 // Module-level inflight trackers — prevent duplicate concurrent requests
@@ -90,6 +91,16 @@ export const useFileTreeStore = create<FileTreeStore>((set, get) => ({
       return {
         expandedDirs: { ...state.expandedDirs, [workspaceId]: next },
       };
+    });
+  },
+
+  expandDir: (contextId: string, dir: string) => {
+    set((state) => {
+      const current = state.expandedDirs[contextId] ?? new Set<string>();
+      if (current.has(dir)) return state;
+      const next = new Set(current);
+      next.add(dir);
+      return { expandedDirs: { ...state.expandedDirs, [contextId]: next } };
     });
   },
 }));

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { applyTheme } from "../lib/themes";
 
-export type RightSidebarTab = "files" | "changes" | "checks" | "bookmarks";
+export type RightSidebarTab = "files" | "changes" | "checks" | "tests";
 export type BottomTab = "setup" | "terminal" | "run" | "activity";
 export type ViewType = "chat" | "settings" | "merge" | "history" | "diff" | "team" | "tests" | "usage" | "activity" | "browser";
 export interface AgentPane {
@@ -41,6 +41,8 @@ interface UIStore {
   rightSidebarVisible: boolean;
   toggleRightSidebar: () => void;
   ensureRightSidebarVisible: () => void;
+  showBookmarksInFiles: boolean;
+  toggleBookmarksInFiles: () => void;
   bottomTab: BottomTab;
   setBottomTab: (tab: BottomTab) => void;
   viewTabs: ViewTab[];
@@ -82,6 +84,9 @@ export const useUIStore = create<UIStore>((set, get) => ({
       set({ rightSidebarVisible: true });
     }
   },
+  showBookmarksInFiles: false,
+  toggleBookmarksInFiles: () =>
+    set((state) => ({ showBookmarksInFiles: !state.showBookmarksInFiles })),
   bottomTab: "setup",
   setBottomTab: (tab) => set({ bottomTab: tab }),
 


### PR DESCRIPTION
## Summary
- **File tree creation**: Add inline file and folder creation to FileTreePanel with new Rust backend commands (`create_workspace_file`, `create_repo_file`, `create_workspace_directory`, `create_repo_directory`) including path traversal validation and comprehensive tests
- **Bookmarks merged into files tab**: Bookmarks now live within the files tab via a toggle rather than a separate right sidebar tab
- **UI polish**: Add tooltips to truncated text across activity/chat/sidebar panels, add test runner commands to command palette, reset plan mode on approval, rename context indicator prop from `workspaceId` to `contextId`, and update README with current feature set and tech stack

## Test plan
- [ ] Verify inline file/folder creation in FileTreePanel works end-to-end
- [ ] Verify bookmarks toggle works correctly in the files tab
- [ ] Verify tooltips appear on truncated text in activity panel, chat TOC, sidebar rows
- [ ] Run `npm test` — all unit tests pass
- [ ] Run `npm run test:e2e` — all E2E tests pass
- [ ] Run `cd src-tauri && cargo test` — all Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)